### PR TITLE
feat: support unified spatial output with masks and points

### DIFF
--- a/src/aec-schema.js
+++ b/src/aec-schema.js
@@ -1,143 +1,44 @@
 /* istanbul ignore file */
 
 export const AEC_PROMPT = `
-You are an AEC computer-vision assistant.
-Return findings strictly matching the provided response schema across FOUR categories:
-1) General objects (e.g., ladder, scaffold, duct, rebar, crane hook).
-2) Facility assets (e.g., exit sign, fire extinguisher, panel/valve).
-3) Safety issues (e.g., missing PPE, unguarded edge, ladder angle > 75°, blocked exit).
-4) Progress/scene insights (e.g., "drywall phase ~70%", "MEP rough-in present", "finishes started").
-
-Geometry:
-- Use bbox as [ymin, xmin, ymax, xmax] array, normalized 0-1000, top-left origin, when localizable.
-- Use polygon only when a box would be misleading (each point {x,y} normalized 0-1000).
-- For whole-image findings (e.g., overall progress), use no geometry under detections (prefer global_insights).
-
-Safety:
-- For safety items, set category: "safety_issue" and fill safety.{isViolation, severity, rule}.
-
-Progress:
-- For per-region progress, set category: "progress" and fill progress.{phase, percentComplete, notes}.
-- For overall progress, prefer global_insights (no geometry).
-
-Attributes:
-- Add useful metadata as {name, valueNum|valueStr|valueBool, unit?}, e.g., {name:"ladder_angle_deg", valueNum:68, unit:"deg"}.
-
-Coordinates:
-- Set image.coordSystem explicitly to "normalized_0_1000" (Google's 0..1000 normalization).
-Be conservative; reflect uncertainty in confidence. Output ONLY JSON (no prose).
+Detect all salient objects in the image.
+Respond with a single JSON object that matches the response schema.
+For each item:
+- Provide "label" with a concise description (avoid prose).
+- Provide "box_2d" as [y0, x0, y1, x1] in the 0-1000 normalized space using a top-left origin.
+- Include "mask" only when a segmentation mask is useful. Encode it as a base64 PNG probability map covering the same region as the box. Use the full PNG data, no prefixes.
+- Include "points" only when useful. Each point must be [y, x] in the same 0-1000 normalized coordinate space.
+Limit to at most 25 items. If uncertain about a region, omit it.
+Output JSON only. Do not include prose, markdown, or code fences.
 `.trim();
 
 export const RESPONSE_SCHEMA = {
-	type: "object",
-	properties: {
-		image: {
-			type: "object",
-			properties: {
-				width: { type: "number", nullable: true },
-				height: { type: "number", nullable: true },
-				fileName: { type: "string", nullable: true },
-				coordSystem: { type: "string", enum: ["normalized_0_1000"], nullable: true, description: "Always normalized_0_1000" }
-			},
-			nullable: true
-		},
-		detections: {
-			type: "array",
-			items: {
-				type: "object",
-				properties: {
-					id: { type: "string" },
-					label: { type: "string" },
-					category: { type: "string", enum: ["object","facility_asset","safety_issue","progress","other"] },
-					confidence: { type: "number" },
-					bbox: {
-						type: "array",
-						items: { type: "number" },
-						minItems: 4,
-						maxItems: 4,
-						description: "[ymin, xmin, ymax, xmax] normalized 0-1000",
-						nullable: true
-					},
-					polygon: {
-						type: "array",
-						items: { type:"object", properties:{ x:{type:"number"}, y:{type:"number"} }, required:["x","y"] },
-						description: "Array of {x,y} points, each normalized 0-1000",
-						nullable: true
-					},
-					safety: {
-						type: "object",
-						properties: {
-							isViolation: { type: "boolean", nullable: true },
-							severity: { type: "string", enum: ["low","medium","high"], nullable: true },
-							rule: { type: "string", nullable: true }
-						},
-						nullable: true
-					},
-					progress: {
-						type: "object",
-						properties: {
-							phase: { type: "string", nullable: true },
-							percentComplete: { type: "number", nullable: true },
-							notes: { type: "string", nullable: true }
-						},
-						nullable: true
-					},
-					attributes: {
-						type: "array",
-						items: {
-							type: "object",
-							properties: {
-								name: { type: "string" },
-								valueStr: { type: "string", nullable: true },
-								valueNum: { type: "number", nullable: true },
-								valueBool: { type: "boolean", nullable: true },
-								unit: { type: "string", nullable: true }
-							},
-							required: ["name"]
-						},
-						nullable: true
-					},
-					useCaseTags: { type: "array", items: { type:"string" }, nullable: true },
-					relationships: {
-						type: "array",
-						items: { type:"object", properties:{ type:{type:"string"}, targetId:{type:"string"} }, required:["type","targetId"] },
-						nullable: true
-					}
-				},
-				required: ["id","label","category","confidence"]
-			}
-		},
-		global_insights: {
-			type: "array",
-			items: {
-				type: "object",
-				properties: {
-					name: { type: "string" },
-					category: { type:"string", enum:["progress","safety_issue","facility_asset","object","other"] },
-					description: { type: "string" },
-					confidence: { type: "number" },
-					metrics: {
-						type: "array",
-						items: { type:"object", properties:{ key:{type:"string"}, value:{type:"number"}, unit:{type:"string",nullable:true} }, required:["key","value"] },
-						nullable: true
-					},
-					relatedDetectionIds: { type:"array", items:{type:"string"}, nullable: true },
-					region: {
-						type: "object",
-						properties: {
-							bbox: {
-								type: "object",
-								properties: { x:{type:"number"}, y:{type:"number"}, width:{type:"number"}, height:{type:"number"} },
-								required: ["x","y","width","height"],
-								nullable: true
-							}
-						},
-						nullable: true
-					}
-				},
-				required: ["name","category","description","confidence"]
-			}
-		}
-	},
-	required: ["detections","global_insights"]
+        type: "object",
+        properties: {
+                items: {
+                        type: "array",
+                        items: {
+                                type: "object",
+                                properties: {
+                                        id: { type: "string", nullable: true },
+                                        label: { type: "string" },
+                                        box_2d: {
+                                                type: "array",
+                                                items: { type: "number" }
+                                        },
+                                        mask: { type: "string", nullable: true },
+                                        points: {
+                                                type: "array",
+                                                items: {
+                                                        type: "array",
+                                                        items: { type: "number" }
+                                                },
+                                                nullable: true
+                                        }
+                                },
+                                required: ["label", "box_2d"]
+                        }
+                }
+        },
+        required: ["items"]
 };

--- a/src/geometry.js
+++ b/src/geometry.js
@@ -40,23 +40,39 @@ export function toCanvasBox(
 }
 
 export function toCanvasPolygon(
-	poly,
-	coordSystem,
-	displayScaleX,
-	displayScaleY,
-	imgW,
-	imgH,
-	origin = 'top-left'
+        poly,
+        coordSystem,
+        displayScaleX,
+        displayScaleY,
+        imgW,
+        imgH,
+        origin = 'top-left'
 ) {
-	if (!Array.isArray(poly)) return null;
+        if (!Array.isArray(poly)) return null;
 
-	const scaledPoints = poly
-		.map(point => normalizePoint(point, coordSystem, imgW, imgH))
-		.map(point => orientPoint(point, origin, imgH))
-		.map(point => scalePoint(point, displayScaleX, displayScaleY))
-		.filter(Boolean);
+        const scaledPoints = poly
+                .map(point => normalizePoint(point, coordSystem, imgW, imgH))
+                .map(point => orientPoint(point, origin, imgH))
+                .map(point => scalePoint(point, displayScaleX, displayScaleY))
+                .filter(Boolean);
 
-	return scaledPoints.length >= 3 ? scaledPoints : null;
+        return scaledPoints.length >= 3 ? scaledPoints : null;
+}
+
+export function toCanvasPoint(
+        point,
+        coordSystem,
+        displayScaleX,
+        displayScaleY,
+        imgW,
+        imgH,
+        origin = 'top-left'
+) {
+        if (!point) return null;
+        const normalized = normalizePoint(point, coordSystem, imgW, imgH);
+        if (!normalized) return null;
+        const oriented = orientPoint(normalized, origin, imgH);
+        return scalePoint(oriented, displayScaleX, displayScaleY);
 }
 
 export function ensureCoordSystem(res, fallback = 'normalized_0_1000') {


### PR DESCRIPTION
## Summary
- switch the Gemini prompt and response schema to a compact items collection so boxes, masks, and points arrive together in one response
- normalize parsed items into the existing detection model, add mask tinting/point rendering helpers, and call the 2.5 Flash endpoint with structured JSON settings and thinking disabled
- update geometry helpers and tests to cover point conversion along with additional coverage for detection normalization and CSV exports

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68dfeca2cc80832cab59682a64d0912b