### PR TITLE
Improve Gemini spatial detections and overlays

### DIFF
--- a/index.html
+++ b/index.html
@@ -64,6 +64,8 @@
   .detection-card-label { font-weight:600; font-size:14px; }
   .detection-card-confidence { font-size:12px; color:#9aa0b4; }
   .detection-card-category { display:inline-block; padding:2px 6px; border-radius:4px; font-size:11px; background:#2a2a3b; color:#cfd5e4; margin-bottom:8px; }
+  .detection-card-geometry { display:flex; flex-wrap:wrap; gap:6px; margin:0 0 8px 0; }
+  .detection-card-geometry span { font-size:11px; background:#1f2435; color:#cfd5e4; padding:2px 6px; border-radius:4px; }
   .detection-card-attrs { font-size:12px; color:#9aa0b4; }
   .detection-card-attrs dt { display:inline; font-weight:600; }
   .detection-card-attrs dd { display:inline; margin:0 0 4px 4px; }
@@ -147,9 +149,9 @@
     <div class="form-group">
       <label for="model">Model</label>
       <select id="model">
-        <option>gemini-2.5-flash</option>
-        <option>gemini-2.5-pro</option>
-        <option>gemini-pro</option>
+        <option>models/gemini-2.5-flash</option>
+        <option>models/gemini-2.5-pro</option>
+        <option>models/gemini-pro</option>
       </select>
     </div>
   </div>

--- a/src/aec-schema.js
+++ b/src/aec-schema.js
@@ -1,143 +1,42 @@
 /* istanbul ignore file */
 
 export const AEC_PROMPT = `
-You are an AEC computer-vision assistant.
-Return findings strictly matching the provided response schema across FOUR categories:
-1) General objects (e.g., ladder, scaffold, duct, rebar, crane hook).
-2) Facility assets (e.g., exit sign, fire extinguisher, panel/valve).
-3) Safety issues (e.g., missing PPE, unguarded edge, ladder angle > 75°, blocked exit).
-4) Progress/scene insights (e.g., "drywall phase ~70%", "MEP rough-in present", "finishes started").
-
-Geometry:
-- Use bbox as [ymin, xmin, ymax, xmax] array, normalized 0-1000, top-left origin, when localizable.
-- Use polygon only when a box would be misleading (each point {x,y} normalized 0-1000).
-- For whole-image findings (e.g., overall progress), use no geometry under detections (prefer global_insights).
-
-Safety:
-- For safety items, set category: "safety_issue" and fill safety.{isViolation, severity, rule}.
-
-Progress:
-- For per-region progress, set category: "progress" and fill progress.{phase, percentComplete, notes}.
-- For overall progress, prefer global_insights (no geometry).
-
-Attributes:
-- Add useful metadata as {name, valueNum|valueStr|valueBool, unit?}, e.g., {name:"ladder_angle_deg", valueNum:68, unit:"deg"}.
-
-Coordinates:
-- Set image.coordSystem explicitly to "normalized_0_1000" (Google's 0..1000 normalization).
-Be conservative; reflect uncertainty in confidence. Output ONLY JSON (no prose).
+Detect objects in the image and respond with JSON only.
+Return a single object with an "items" array (maximum 25 entries).
+Each item must include:
+- "label": short descriptive text.
+- "box_2d": [y0, x0, y1, x1] with values normalized 0-1000 using a top-left origin.
+Optionally include:
+- "mask": base64-encoded PNG probability map for the object (omit when unavailable).
+- "points": array of [y, x] pairs normalized 0-1000 highlighting key locations (omit when unavailable).
+Do not include prose or code fences in the response.
 `.trim();
 
 export const RESPONSE_SCHEMA = {
-	type: "object",
-	properties: {
-		image: {
-			type: "object",
-			properties: {
-				width: { type: "number", nullable: true },
-				height: { type: "number", nullable: true },
-				fileName: { type: "string", nullable: true },
-				coordSystem: { type: "string", enum: ["normalized_0_1000"], nullable: true, description: "Always normalized_0_1000" }
-			},
-			nullable: true
-		},
-		detections: {
-			type: "array",
-			items: {
-				type: "object",
-				properties: {
-					id: { type: "string" },
-					label: { type: "string" },
-					category: { type: "string", enum: ["object","facility_asset","safety_issue","progress","other"] },
-					confidence: { type: "number" },
-					bbox: {
-						type: "array",
-						items: { type: "number" },
-						minItems: 4,
-						maxItems: 4,
-						description: "[ymin, xmin, ymax, xmax] normalized 0-1000",
-						nullable: true
-					},
-					polygon: {
-						type: "array",
-						items: { type:"object", properties:{ x:{type:"number"}, y:{type:"number"} }, required:["x","y"] },
-						description: "Array of {x,y} points, each normalized 0-1000",
-						nullable: true
-					},
-					safety: {
-						type: "object",
-						properties: {
-							isViolation: { type: "boolean", nullable: true },
-							severity: { type: "string", enum: ["low","medium","high"], nullable: true },
-							rule: { type: "string", nullable: true }
-						},
-						nullable: true
-					},
-					progress: {
-						type: "object",
-						properties: {
-							phase: { type: "string", nullable: true },
-							percentComplete: { type: "number", nullable: true },
-							notes: { type: "string", nullable: true }
-						},
-						nullable: true
-					},
-					attributes: {
-						type: "array",
-						items: {
-							type: "object",
-							properties: {
-								name: { type: "string" },
-								valueStr: { type: "string", nullable: true },
-								valueNum: { type: "number", nullable: true },
-								valueBool: { type: "boolean", nullable: true },
-								unit: { type: "string", nullable: true }
-							},
-							required: ["name"]
-						},
-						nullable: true
-					},
-					useCaseTags: { type: "array", items: { type:"string" }, nullable: true },
-					relationships: {
-						type: "array",
-						items: { type:"object", properties:{ type:{type:"string"}, targetId:{type:"string"} }, required:["type","targetId"] },
-						nullable: true
-					}
-				},
-				required: ["id","label","category","confidence"]
-			}
-		},
-		global_insights: {
-			type: "array",
-			items: {
-				type: "object",
-				properties: {
-					name: { type: "string" },
-					category: { type:"string", enum:["progress","safety_issue","facility_asset","object","other"] },
-					description: { type: "string" },
-					confidence: { type: "number" },
-					metrics: {
-						type: "array",
-						items: { type:"object", properties:{ key:{type:"string"}, value:{type:"number"}, unit:{type:"string",nullable:true} }, required:["key","value"] },
-						nullable: true
-					},
-					relatedDetectionIds: { type:"array", items:{type:"string"}, nullable: true },
-					region: {
-						type: "object",
-						properties: {
-							bbox: {
-								type: "object",
-								properties: { x:{type:"number"}, y:{type:"number"}, width:{type:"number"}, height:{type:"number"} },
-								required: ["x","y","width","height"],
-								nullable: true
-							}
-						},
-						nullable: true
-					}
-				},
-				required: ["name","category","description","confidence"]
-			}
-		}
-	},
-	required: ["detections","global_insights"]
+        type: "object",
+        properties: {
+                items: {
+                        type: "array",
+                        items: {
+                                type: "object",
+                                properties: {
+                                        label: { type: "string" },
+                                        box_2d: {
+                                                type: "array",
+                                                items: { type: "number" }
+                                        },
+                                        mask: { type: "string" },
+                                        points: {
+                                                type: "array",
+                                                items: {
+                                                        type: "array",
+                                                        items: { type: "number" }
+                                                }
+                                        }
+                                },
+                                required: ["label", "box_2d"]
+                        }
+                }
+        },
+        required: ["items"]
 };

--- a/src/geometry.js
+++ b/src/geometry.js
@@ -40,23 +40,43 @@ export function toCanvasBox(
 }
 
 export function toCanvasPolygon(
-	poly,
-	coordSystem,
-	displayScaleX,
-	displayScaleY,
-	imgW,
-	imgH,
-	origin = 'top-left'
+        poly,
+        coordSystem,
+        displayScaleX,
+        displayScaleY,
+        imgW,
+        imgH,
+        origin = 'top-left'
 ) {
-	if (!Array.isArray(poly)) return null;
+        if (!Array.isArray(poly)) return null;
 
-	const scaledPoints = poly
-		.map(point => normalizePoint(point, coordSystem, imgW, imgH))
-		.map(point => orientPoint(point, origin, imgH))
-		.map(point => scalePoint(point, displayScaleX, displayScaleY))
-		.filter(Boolean);
+        const scaledPoints = poly
+                .map(point => normalizePoint(point, coordSystem, imgW, imgH))
+                .map(point => orientPoint(point, origin, imgH))
+                .map(point => scalePoint(point, displayScaleX, displayScaleY))
+                .filter(Boolean);
 
-	return scaledPoints.length >= 3 ? scaledPoints : null;
+        return scaledPoints.length >= 3 ? scaledPoints : null;
+}
+
+export function toCanvasPoint(
+        point,
+        coordSystem,
+        displayScaleX,
+        displayScaleY,
+        imgW,
+        imgH,
+        origin = 'top-left'
+) {
+        if (Array.isArray(point) && point.length >= 2) {
+                point = { y: point[0], x: point[1] };
+        }
+
+        const normalized = normalizePoint(point, coordSystem, imgW, imgH);
+        if (!normalized) return null;
+
+        const oriented = orientPoint(normalized, origin, imgH);
+        return scalePoint(oriented, displayScaleX, displayScaleY);
 }
 
 export function ensureCoordSystem(res, fallback = 'normalized_0_1000') {

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -1,8 +1,9 @@
 import {
-	toCanvasBox,
-	toCanvasPolygon,
-	ensureCoordOrigin,
-	ensureCoordSystem
+        toCanvasBox,
+        toCanvasPolygon,
+        toCanvasPoint,
+        ensureCoordOrigin,
+        ensureCoordSystem
 } from './geometry.js';
 import { clamp } from './math.js';
 
@@ -138,10 +139,21 @@ describe('geometry helpers', () => {
     ]);
   });
 
-	test('ensureCoordOrigin falls back to detections when image metadata missing', () => {
-		const parsed = {
-			image: {},
-			detections: [{ coordOrigin: 'bottom-left' }]
+  test('toCanvasPoint converts normalized [y, x] arrays into canvas coordinates', () => {
+    const point = [250, 750];
+    const result = toCanvasPoint(point, 'normalized_0_1000', 0.5, 0.5, naturalW, naturalH, 'top-left');
+    expect(result).toEqual({ x: 75, y: 12.5 });
+  });
+
+  test('toCanvasPoint returns null for invalid points', () => {
+    expect(toCanvasPoint([NaN, 10], 'normalized_0_1000', 1, 1, naturalW, naturalH, 'top-left')).toBeNull();
+    expect(toCanvasPoint(null, 'normalized_0_1000', 1, 1, naturalW, naturalH, 'top-left')).toBeNull();
+  });
+
+        test('ensureCoordOrigin falls back to detections when image metadata missing', () => {
+                const parsed = {
+                        image: {},
+                        detections: [{ coordOrigin: 'bottom-left' }]
 		};
 		expect(ensureCoordOrigin(parsed, 'top-left')).toBe('bottom-left');
 	});

--- a/src/report-ui.js
+++ b/src/report-ui.js
@@ -272,28 +272,43 @@ function renderDetectionCards(detections) {
 		const category = det.category || 'other';
 		const categoryLabel = category.replace(/_/g, ' ');
 
-		let attrsHtml = '';
-		if (Array.isArray(det.attributes) && det.attributes.length > 0) {
-			attrsHtml = '<dl class="detection-card-attrs">';
-			det.attributes.forEach(attr => {
-				const value = attr.valueNum ?? attr.valueStr ?? attr.valueBool ?? '—';
-				const unit = attr.unit ? ` ${attr.unit}` : '';
-				attrsHtml += `<dt>${escapeHtml(attr.name)}:</dt><dd>${value}${unit}</dd><br>`;
-			});
-			attrsHtml += '</dl>';
-		}
+                let attrsHtml = '';
+                if (Array.isArray(det.attributes) && det.attributes.length > 0) {
+                        attrsHtml = '<dl class="detection-card-attrs">';
+                        det.attributes.forEach(attr => {
+                                const value = attr.valueNum ?? attr.valueStr ?? attr.valueBool ?? '—';
+                                const unit = attr.unit ? ` ${attr.unit}` : '';
+                                attrsHtml += `<dt>${escapeHtml(attr.name)}:</dt><dd>${value}${unit}</dd><br>`;
+                        });
+                        attrsHtml += '</dl>';
+                }
 
-		return `
-			<div class="detection-card category-${category}" data-detection-id="${det.id || ''}">
-				<div class="detection-card-header">
-					<div class="detection-card-label">${escapeHtml(det.label)}</div>
-					<div class="detection-card-confidence">${confidence}%</div>
-				</div>
-				<div class="detection-card-category">${escapeHtml(categoryLabel)}</div>
-				${attrsHtml}
-			</div>
-		`;
-	}).join('');
+                const geometryTags = [];
+                if (Array.isArray(det.bbox) || Array.isArray(det.box_2d)) {
+                        geometryTags.push('Box');
+                }
+                if (det.mask) {
+                        geometryTags.push('Mask');
+                }
+                if (Array.isArray(det.points) && det.points.length > 0) {
+                        geometryTags.push(det.points.length === 1 ? 'Point' : `${det.points.length} points`);
+                }
+                const geometryHtml = geometryTags.length > 0
+                        ? `<div class="detection-card-geometry">${geometryTags.map(tag => `<span>${escapeHtml(tag)}</span>`).join('')}</div>`
+                        : '';
+
+                return `
+                        <div class="detection-card category-${category}" data-detection-id="${det.id || ''}">
+                                <div class="detection-card-header">
+                                        <div class="detection-card-label">${escapeHtml(det.label)}</div>
+                                        <div class="detection-card-confidence">${confidence}%</div>
+                                </div>
+                                <div class="detection-card-category">${escapeHtml(categoryLabel)}</div>
+                                ${geometryHtml}
+                                ${attrsHtml}
+                        </div>
+                `;
+        }).join('');
 
 	return `<div class="detection-grid">${cards}</div>`;
 }


### PR DESCRIPTION
## Summary
- simplify the Gemini prompt and schema to request boxes, masks, and points in a single JSON payload
- tune the REST call for gemini-2.5-flash with zero temperature, normalize the structured response, and render cached mask/point overlays on the canvas
- surface geometry badges in the report so detections that include masks or points are easy to spot

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68dfeca2cc80832cab59682a64d0912b