### PR TITLE
V5

### DIFF
--- a/docs/spatial-understanding-improvements.md
+++ b/docs/spatial-understanding-improvements.md
@@ -166,7 +166,7 @@ const segmentationColors = [
 
 ## References
 
-1. Google's spatial understanding demo: `/referenceImplementations/genini-spatial-understanding-demo`
+1. Google's spatial understanding demo: `/referenceImplementations/gemini-spatial-understanding-demo`
 2. Gemini 2.5 spatial understanding docs: https://developers.googleblog.com/en/conversational-image-segmentation-gemini-2-5/
 3. Structured output guidelines: https://ai.google.dev/gemini-api/docs/structured-output
 4. 2D spatial understanding colab: https://colab.research.google.com/github/google-gemini/cookbook/blob/main/quickstarts/Spatial_understanding.ipynb

--- a/docs/spatial-understanding-improvements.md
+++ b/docs/spatial-understanding-improvements.md
@@ -1,0 +1,181 @@
+# Spatial Understanding Improvements
+
+## Overview
+
+This document describes the improvements made to enhance bounding box accuracy and add support for segmentation masks and points visualization, based on learnings from Google's reference implementation.
+
+## Key Changes
+
+### 1. API Configuration
+
+**Model Selection:**
+- Changed default model from `gemini-2.5-pro` to `gemini-2.5-flash`
+- Added `thinkingConfig: {thinkingBudget: 0}` for optimal spatial understanding performance
+- This configuration is recommended by Google for spatial tasks per their reference implementation
+
+**Location:** `src/index.js` lines 356-372, 549
+
+### 2. Simplified Prompt
+
+**Before:**
+- Complex AEC-specific prompt with multiple categories, detailed geometry instructions, and nested requirements
+- ~30 lines of detailed instructions
+
+**After:**
+- Direct, concise prompt focused on detection task
+- Clear request for boxes, masks, and points in a single call
+- Explicit limit of 25 items to improve response quality
+- No prose or code fences in output
+
+**Location:** `src/aec-schema.js` lines 3-10
+
+### 3. Simplified Response Schema
+
+**Before:**
+- Complex nested schema with `detections` and `global_insights`
+- Multiple enums for categories (5 values)
+- Nested objects for safety, progress, attributes, relationships
+- `minItems`/`maxItems` constraints
+- Polygon support with complex point objects `{x, y}`
+
+**After:**
+- Simple flat `items` array
+- Each item contains:
+  - `label` (string, required)
+  - `box_2d` (array of 4 numbers, required) - `[ymin, xmin, ymax, xmax]` normalized 0-1000
+  - `mask` (string, optional) - base64-encoded PNG
+  - `points` (array of arrays, optional) - `[[y, x], ...]` normalized 0-1000
+  - `category` (string, optional) - simple string, no enum
+  - `confidence` (number, optional) - 0-1 confidence
+
+**Why this matters:**
+- Reduces "too many states for serving" errors
+- Allows model to return all spatial data (boxes, masks, points) in single response
+- Simpler structure = better model performance
+- Follows Google's reference implementation pattern
+
+**Location:** `src/aec-schema.js` lines 31-52
+
+### 4. Response Format Transformation
+
+**Implementation:**
+- Added `transformResponseFormat()` function in `src/ui-utils.js`
+- Converts new simplified format to legacy format for backward compatibility
+- Allows UI code to remain unchanged while using improved API
+
+**Transformation mapping:**
+- `items` → `detections` array
+- Adds auto-generated IDs (`det_0`, `det_1`, etc.)
+- Preserves `mask` and `points` fields when present
+- Adds default values for missing fields (category: 'object', confidence: 0.8)
+
+**Location:** `src/ui-utils.js` lines 134-176
+
+### 5. Segmentation Mask Visualization
+
+**New capability:**
+- Renders base64 PNG masks as colored overlays
+- Uses color palette from reference implementation
+- 50% opacity for visibility of underlying image
+- Mask drawn as background layer before boxes
+
+**Technical details:**
+- Converts grayscale mask to RGBA with color palette
+- Scales mask to bounding box dimensions
+- Uses off-screen canvas for pixel manipulation
+
+**Location:** `src/index.js` lines 102-108, 376-414
+
+**Color palette:**
+```javascript
+const segmentationColors = [
+  [230, 25, 75],    // Red
+  [60, 180, 75],    // Green
+  [255, 225, 25],   // Yellow
+  [0, 130, 200],    // Blue
+  [245, 130, 48],   // Orange
+  [145, 30, 180],   // Purple
+  [70, 240, 240],   // Cyan
+  [240, 50, 230],   // Magenta
+  [191, 239, 69],   // Lime
+  [250, 190, 212]   // Pink
+]
+```
+
+### 6. Points Visualization
+
+**New capability:**
+- Renders point arrays as colored circles on canvas
+- Supports `[y, x]` format normalized to 0-1000
+- White border around points for visibility
+- Label shown at first point only
+
+**Technical details:**
+- 6px radius circles
+- 2px white stroke
+- Color matches category
+
+**Location:** `src/index.js` lines 154-159, 416-448
+
+## Testing
+
+**Test coverage:**
+- Added comprehensive tests for `transformResponseFormat()`
+- Tests cover:
+  - Basic transformation from items to detections
+  - Mask field preservation
+  - Points field preservation
+  - Default value handling
+  - Legacy format pass-through
+  - Invalid input handling
+
+**Location:** `src/ui-utils.test.js` lines 336-435
+
+**Test results:**
+- All 128 tests pass
+- Coverage: 97.78% statements, 90.82% branches, 98.48% functions
+
+## Benefits
+
+### Improved Bounding Box Accuracy
+- Simplified prompt allows model to focus on spatial task
+- Reduced schema complexity prevents state explosion
+- Optimized model configuration (thinkingBudget: 0)
+
+### Single API Call for All Spatial Data
+- Previously: Multiple calls needed for different output types
+- Now: Single call returns boxes, masks, and points simultaneously
+- Reduces API costs and latency
+
+### Better Visualization
+- Segmentation masks show precise object boundaries
+- Points highlight key locations
+- Color-coded by category for easy identification
+
+## Migration Notes
+
+### For Existing Code
+- Response structure automatically transformed to legacy format
+- Existing UI code requires no changes
+- All existing tests continue to pass
+
+### For New Features
+- Can access `mask` field directly from detections
+- Can access `points` array directly from detections
+- Format: `detection.mask` (base64 string), `detection.points` (array of [y,x] pairs)
+
+## References
+
+1. Google's spatial understanding demo: `/referenceImplementations/genini-spatial-understanding-demo`
+2. Gemini 2.5 spatial understanding docs: https://developers.googleblog.com/en/conversational-image-segmentation-gemini-2-5/
+3. Structured output guidelines: https://ai.google.dev/gemini-api/docs/structured-output
+4. 2D spatial understanding colab: https://colab.research.google.com/github/google-gemini/cookbook/blob/main/quickstarts/Spatial_understanding.ipynb
+
+## Future Improvements
+
+Potential enhancements not included in this change:
+- Interactive mask editing
+- Point annotation tools
+- 3D bounding box support
+- Mask-based object selection
+- Export masks as separate PNG files

--- a/index.html
+++ b/index.html
@@ -147,7 +147,7 @@
     <div class="form-group">
       <label for="model">Model</label>
       <select id="model">
-        <option>gemini-2.5-flash</option>
+        <option selected>gemini-2.5-flash</option>
         <option>gemini-2.5-pro</option>
         <option>gemini-pro</option>
       </select>

--- a/referenceImplementations/genini-spatial-understanding-demo/.gitignore
+++ b/referenceImplementations/genini-spatial-understanding-demo/.gitignore
@@ -1,0 +1,24 @@
+# Logs
+logs
+*.log
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+pnpm-debug.log*
+lerna-debug.log*
+
+node_modules
+dist
+dist-ssr
+*.local
+
+# Editor directories and files
+.vscode/*
+!.vscode/extensions.json
+.idea
+.DS_Store
+*.suo
+*.ntvs*
+*.njsproj
+*.sln
+*.sw?

--- a/referenceImplementations/genini-spatial-understanding-demo/App.tsx
+++ b/referenceImplementations/genini-spatial-understanding-demo/App.tsx
@@ -1,0 +1,100 @@
+/**
+ * @license
+ * SPDX-License-Identifier: Apache-2.0
+*/
+/* tslint:disable */
+// Copyright 2024 Google LLC
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+
+//     https://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import {useAtom} from 'jotai';
+import {useEffect} from 'react';
+import {Content} from './Content';
+import {DetectTypeSelector} from './DetectTypeSelector';
+import {ExampleImages} from './ExampleImages';
+import {ExtraModeControls} from './ExtraModeControls';
+import {Prompt} from './Prompt';
+import {SideControls} from './SideControls';
+import {TopBar} from './TopBar';
+import {DetectTypes} from './Types';
+import {
+  BumpSessionAtom,
+  DetectTypeAtom,
+  ImageSrcAtom,
+  InitFinishedAtom,
+  IsUploadedImageAtom,
+} from './atoms';
+import {useResetState} from './hooks';
+import {hash} from './utils';
+
+function App() {
+  const [, setImageSrc] = useAtom(ImageSrcAtom);
+  const resetState = useResetState();
+  const [initFinished, setInitFinished] = useAtom(InitFinishedAtom);
+  const [, setBumpSession] = useAtom(BumpSessionAtom);
+  const [, setIsUploadedImage] = useAtom(IsUploadedImageAtom);
+  const [, setDetectType] = useAtom(DetectTypeAtom);
+
+  useEffect(() => {
+    if (!window.matchMedia('(prefers-color-scheme: dark)').matches) {
+      document.documentElement.classList.remove('dark');
+    }
+    const params = hash();
+    const taskParam = params.task;
+
+    if (taskParam) {
+      let newDetectType: DetectTypes | null = null;
+      switch (taskParam) {
+        case '2d-bounding-boxes':
+          newDetectType = '2D bounding boxes';
+          break;
+        case 'segmentation-masks':
+          newDetectType = 'Segmentation masks';
+          break;
+        case 'points':
+          newDetectType = 'Points';
+          break;
+        case '3d-bounding-boxes':
+          newDetectType = '3D bounding boxes';
+          break;
+        default:
+          console.warn(`Unknown task parameter in URL hash: ${taskParam}`);
+      }
+      if (newDetectType) {
+        setDetectType(newDetectType);
+      }
+    }
+  }, [setDetectType]);
+
+  return (
+    <div className="flex flex-col h-[100dvh]">
+      <div className="flex grow flex-col border-b overflow-hidden">
+        <TopBar />
+        {initFinished ? <Content /> : null}
+        <ExtraModeControls />
+      </div>
+      <div className="flex shrink-0 w-full overflow-auto py-6 px-5 gap-6 lg:items-start">
+        <div className="flex flex-col lg:flex-col gap-6 items-center border-r pr-5">
+          <ExampleImages />
+          <SideControls />
+        </div>
+        <div className="flex flex-row gap-6 grow">
+          <DetectTypeSelector />
+          <Prompt />
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default App;

--- a/referenceImplementations/genini-spatial-understanding-demo/Content.tsx
+++ b/referenceImplementations/genini-spatial-understanding-demo/Content.tsx
@@ -1,0 +1,555 @@
+/**
+ * @license
+ * SPDX-License-Identifier: Apache-2.0
+*/
+/* tslint:disable */
+// Copyright 2024 Google LLC
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+
+//     https://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import {useAtom} from 'jotai';
+import getStroke from 'perfect-freehand';
+import {useCallback, useEffect, useMemo, useRef, useState} from 'react';
+import {ResizePayload, useResizeDetector} from 'react-resize-detector';
+import {
+  ActiveColorAtom,
+  BoundingBoxes2DAtom,
+  BoundingBoxes3DAtom,
+  BoundingBoxMasksAtom,
+  DetectTypeAtom,
+  DrawModeAtom,
+  FOVAtom,
+  ImageSentAtom,
+  ImageSrcAtom,
+  LinesAtom,
+  PointsAtom,
+  RevealOnHoverModeAtom,
+  ShareStream,
+  VideoRefAtom,
+} from './atoms';
+import {lineOptions, segmentationColorsRgb} from './consts';
+import {getSvgPathFromStroke} from './utils';
+
+export function Content() {
+  const [imageSrc] = useAtom(ImageSrcAtom);
+  const [boundingBoxes2D] = useAtom(BoundingBoxes2DAtom);
+  const [boundingBoxes3D] = useAtom(BoundingBoxes3DAtom);
+  const [boundingBoxMasks] = useAtom(BoundingBoxMasksAtom);
+  const [stream] = useAtom(ShareStream);
+  const [detectType] = useAtom(DetectTypeAtom);
+  const [videoRef] = useAtom(VideoRefAtom);
+  const [fov] = useAtom(FOVAtom);
+  const [, setImageSent] = useAtom(ImageSentAtom);
+  const [points] = useAtom(PointsAtom);
+  const [revealOnHover] = useAtom(RevealOnHoverModeAtom);
+  const [hoverEntered, setHoverEntered] = useState(false);
+  const [hoveredBox, _setHoveredBox] = useState<number | null>(null);
+  const [drawMode] = useAtom(DrawModeAtom);
+  const [lines, setLines] = useAtom(LinesAtom);
+  const [activeColor] = useAtom(ActiveColorAtom);
+
+  // Handling resize and aspect ratios
+  const boundingBoxContainerRef = useRef<HTMLDivElement | null>(null);
+  const [containerDims, setContainerDims] = useState({
+    width: 0,
+    height: 0,
+  });
+  const [activeMediaDimensions, setActiveMediaDimensions] = useState({
+    width: 1,
+    height: 1,
+  });
+
+  const onResize = useCallback((el: ResizePayload) => {
+    if (el.width && el.height) {
+      setContainerDims({
+        width: el.width,
+        height: el.height,
+      });
+    }
+  }, []);
+
+  const {ref: containerRef} = useResizeDetector({onResize});
+
+  const boundingBoxContainer = useMemo(() => {
+    const {width, height} = activeMediaDimensions;
+    const aspectRatio = width / height;
+    const containerAspectRatio = containerDims.width / containerDims.height;
+    if (aspectRatio < containerAspectRatio) {
+      return {
+        height: containerDims.height,
+        width: containerDims.height * aspectRatio,
+      };
+    } else {
+      return {
+        width: containerDims.width,
+        height: containerDims.width / aspectRatio,
+      };
+    }
+  }, [containerDims, activeMediaDimensions]);
+
+  // Helper functions
+  function matrixMultiply(m: number[][], v: number[]): number[] {
+    return m.map((row: number[]) =>
+      row.reduce((sum, val, i) => sum + val * v[i], 0),
+    );
+  }
+
+  const linesAndLabels3D = useMemo(() => {
+    if (!boundingBoxContainer) {
+      return null;
+    }
+    let allLines = [];
+    let allLabels = [];
+    for (const box of boundingBoxes3D) {
+      const {center, size, rpy} = box;
+
+      // Convert Euler angles to quaternion
+      const [sr, sp, sy] = rpy.map((x) => Math.sin(x / 2));
+      const [cr, cp, cz] = rpy.map((x) => Math.cos(x / 2));
+      const quaternion = [
+        sr * cp * cz - cr * sp * sy,
+        cr * sp * cz + sr * cp * sy,
+        cr * cp * sy - sr * sp * cz,
+        cr * cp * cz + sr * sp * sy,
+      ];
+
+      // Calculate camera parameters
+      const height = boundingBoxContainer.height;
+      const width = boundingBoxContainer.width;
+      const f = width / (2 * Math.tan(((fov / 2) * Math.PI) / 180));
+      const cx = width / 2;
+      const cy = height / 2;
+      const intrinsics = [
+        [f, 0, cx],
+        [0, f, cy],
+        [0, 0, 1],
+      ];
+
+      // Get box vertices
+      const halfSize = size.map((s) => s / 2);
+      let corners = [];
+      for (let x of [-halfSize[0], halfSize[0]]) {
+        for (let y of [-halfSize[1], halfSize[1]]) {
+          for (let z of [-halfSize[2], halfSize[2]]) {
+            corners.push([x, y, z]);
+          }
+        }
+      }
+      corners = [
+        corners[1],
+        corners[3],
+        corners[7],
+        corners[5],
+        corners[0],
+        corners[2],
+        corners[6],
+        corners[4],
+      ];
+
+      // Apply rotation from quaternion
+      const q = quaternion;
+      const rotationMatrix = [
+        [
+          1 - 2 * q[1] ** 2 - 2 * q[2] ** 2,
+          2 * q[0] * q[1] - 2 * q[3] * q[2],
+          2 * q[0] * q[2] + 2 * q[3] * q[1],
+        ],
+        [
+          2 * q[0] * q[1] + 2 * q[3] * q[2],
+          1 - 2 * q[0] ** 2 - 2 * q[2] ** 2,
+          2 * q[1] * q[2] - 2 * q[3] * q[0],
+        ],
+        [
+          2 * q[0] * q[2] - 2 * q[3] * q[1],
+          2 * q[1] * q[2] + 2 * q[3] * q[0],
+          1 - 2 * q[0] ** 2 - 2 * q[1] ** 2,
+        ],
+      ];
+
+      const boxVertices = corners.map((corner) => {
+        const rotated = matrixMultiply(rotationMatrix, corner);
+        return rotated.map((val, idx) => val + center[idx]);
+      });
+
+      // Project 3D points to 2D
+      const tiltAngle = 90.0;
+      const viewRotationMatrix = [
+        [1, 0, 0],
+        [
+          0,
+          Math.cos((tiltAngle * Math.PI) / 180),
+          -Math.sin((tiltAngle * Math.PI) / 180),
+        ],
+        [
+          0,
+          Math.sin((tiltAngle * Math.PI) / 180),
+          Math.cos((tiltAngle * Math.PI) / 180),
+        ],
+      ];
+
+      const points = boxVertices;
+      const rotatedPoints = points.map((p) =>
+        matrixMultiply(viewRotationMatrix, p),
+      );
+      const translatedPoints = rotatedPoints.map((p) => p.map((v) => v + 0));
+      const projectedPoints = translatedPoints.map((p) =>
+        matrixMultiply(intrinsics, p),
+      );
+      const vertices = projectedPoints.map((p) => [p[0] / p[2], p[1] / p[2]]);
+
+      const topVertices = vertices.slice(0, 4);
+      const bottomVertices = vertices.slice(4, 8);
+
+      for (let i = 0; i < 4; i++) {
+        const lines = [
+          [topVertices[i], topVertices[(i + 1) % 4]],
+          [bottomVertices[i], bottomVertices[(i + 1) % 4]],
+          [topVertices[i], bottomVertices[i]],
+        ];
+
+        for (let [start, end] of lines) {
+          const dx = end[0] - start[0];
+          const dy = end[1] - start[1];
+          const length = Math.sqrt(dx * dx + dy * dy);
+          const angle = Math.atan2(dy, dx);
+
+          allLines.push({start, end, length, angle});
+        }
+      }
+
+      // Add label with fade effect
+      const textPosition3d = points[0].map(
+        (_, idx) => points.reduce((sum, p) => sum + p[idx], 0) / points.length,
+      );
+      textPosition3d[2] += 0.1;
+
+      const textPoint = matrixMultiply(
+        intrinsics,
+        matrixMultiply(
+          viewRotationMatrix,
+          textPosition3d.map((v) => v + 0),
+        ),
+      );
+      const textPos = [
+        textPoint[0] / textPoint[2],
+        textPoint[1] / textPoint[2],
+      ];
+      allLabels.push({label: box.label, pos: textPos});
+    }
+    return [allLines, allLabels] as const;
+  }, [boundingBoxes3D, boundingBoxContainer, fov]);
+
+  function setHoveredBox(e: React.PointerEvent) {
+    const boxes = document.querySelectorAll('.bbox');
+    const dimensionsAndIndex = Array.from(boxes).map((box, i) => {
+      const {top, left, width, height} = box.getBoundingClientRect();
+      return {
+        top,
+        left,
+        width,
+        height,
+        index: i,
+      };
+    });
+    // Sort smallest to largest
+    const sorted = dimensionsAndIndex.sort(
+      (a, b) => a.width * a.height - b.width * b.height,
+    );
+    // Find the smallest box that contains the mouse
+    const {clientX, clientY} = e;
+    const found = sorted.find(({top, left, width, height}) => {
+      return (
+        clientX > left &&
+        clientX < left + width &&
+        clientY > top &&
+        clientY < top + height
+      );
+    });
+    if (found) {
+      _setHoveredBox(found.index);
+    } else {
+      _setHoveredBox(null);
+    }
+  }
+
+  const downRef = useRef<Boolean>(false);
+
+  return (
+    <div ref={containerRef} className="w-full grow relative">
+      {stream ? (
+        <video
+          className="absolute top-0 left-0 w-full h-full object-contain"
+          autoPlay
+          onLoadedMetadata={(e) => {
+            setActiveMediaDimensions({
+              width: e.currentTarget.videoWidth,
+              height: e.currentTarget.videoHeight,
+            });
+          }}
+          ref={(video) => {
+            videoRef.current = video;
+            if (video && !video.srcObject) {
+              video.srcObject = stream;
+            }
+          }}
+        />
+      ) : imageSrc ? (
+        <img
+          src={imageSrc}
+          className="absolute top-0 left-0 w-full h-full object-contain"
+          alt="Uploaded image"
+          onLoad={(e) => {
+            setActiveMediaDimensions({
+              width: e.currentTarget.naturalWidth,
+              height: e.currentTarget.naturalHeight,
+            });
+          }}
+        />
+      ) : null}
+      <div
+        className={`absolute w-full h-full left-1/2 top-1/2 transform -translate-x-1/2 -translate-y-1/2 ${hoverEntered ? 'hide-box' : ''} ${drawMode ? 'cursor-crosshair' : ''}`}
+        ref={boundingBoxContainerRef}
+        onPointerEnter={(e) => {
+          if (revealOnHover && !drawMode) {
+            setHoverEntered(true);
+            setHoveredBox(e);
+          }
+        }}
+        onPointerMove={(e) => {
+          if (revealOnHover && !drawMode) {
+            setHoverEntered(true);
+            setHoveredBox(e);
+          }
+          if (downRef.current) {
+            const parentBounds =
+              boundingBoxContainerRef.current!.getBoundingClientRect();
+            setLines((prev) => [
+              ...prev.slice(0, prev.length - 1),
+              [
+                [
+                  ...prev[prev.length - 1][0],
+                  [
+                    (e.clientX - parentBounds.left) /
+                      boundingBoxContainer!.width,
+                    (e.clientY - parentBounds.top) /
+                      boundingBoxContainer!.height,
+                  ],
+                ],
+                prev[prev.length - 1][1],
+              ],
+            ]);
+          }
+        }}
+        onPointerLeave={(e) => {
+          if (revealOnHover && !drawMode) {
+            setHoverEntered(false);
+            setHoveredBox(e);
+          }
+        }}
+        onPointerDown={(e) => {
+          if (drawMode) {
+            setImageSent(false);
+            (e.target as HTMLElement).setPointerCapture(e.pointerId);
+            downRef.current = true;
+            const parentBounds =
+              boundingBoxContainerRef.current!.getBoundingClientRect();
+            setLines((prev) => [
+              ...prev,
+              [
+                [
+                  [
+                    (e.clientX - parentBounds.left) /
+                      boundingBoxContainer!.width,
+                    (e.clientY - parentBounds.top) /
+                      boundingBoxContainer!.height,
+                  ],
+                ],
+                activeColor,
+              ],
+            ]);
+          }
+        }}
+        onPointerUp={(e) => {
+          if (drawMode) {
+            (e.target as HTMLElement).releasePointerCapture(e.pointerId);
+            downRef.current = false;
+          }
+        }}
+        style={{
+          width: boundingBoxContainer.width,
+          height: boundingBoxContainer.height,
+        }}>
+        {lines.length > 0 && (
+          <svg
+            className="absolute top-0 left-0 w-full h-full"
+            style={{
+              pointerEvents: 'none',
+              width: boundingBoxContainer?.width,
+              height: boundingBoxContainer?.height,
+            }}>
+            {lines.map(([points, color], i) => (
+              <path
+                key={i}
+                d={getSvgPathFromStroke(
+                  getStroke(
+                    points.map(([x, y]) => [
+                      x * boundingBoxContainer!.width,
+                      y * boundingBoxContainer!.height,
+                      0.5,
+                    ]),
+                    lineOptions,
+                  ),
+                )}
+                fill={color}
+              />
+            ))}
+          </svg>
+        )}
+        {detectType === '2D bounding boxes' &&
+          boundingBoxes2D.map((box, i) => (
+            <div
+              key={i}
+              className={`absolute bbox border-2 border-[#3B68FF] ${i === hoveredBox ? 'reveal' : ''}`}
+              style={{
+                transformOrigin: '0 0',
+                top: box.y * 100 + '%',
+                left: box.x * 100 + '%',
+                width: box.width * 100 + '%',
+                height: box.height * 100 + '%',
+              }}>
+              <div className="bg-[#3B68FF] text-white absolute left-0 top-0 text-sm px-1">
+                {box.label}
+              </div>
+            </div>
+          ))}
+        {detectType === 'Segmentation masks' &&
+          boundingBoxMasks.map((box, i) => (
+            <div
+              key={i}
+              className={`absolute bbox border-2 border-[#3B68FF] ${i === hoveredBox ? 'reveal' : ''}`}
+              style={{
+                transformOrigin: '0 0',
+                top: box.y * 100 + '%',
+                left: box.x * 100 + '%',
+                width: box.width * 100 + '%',
+                height: box.height * 100 + '%',
+              }}>
+              <BoxMask box={box} index={i} />
+              <div className="w-full top-0 h-0 absolute">
+                <div className="bg-[#3B68FF] text-white absolute -left-[2px] bottom-0 text-sm px-1">
+                  {box.label}
+                </div>
+              </div>
+            </div>
+          ))}
+
+        {detectType === 'Points' &&
+          points.map((point, i) => {
+            return (
+              <div
+                key={i}
+                className="absolute bg-red"
+                style={{
+                  left: `${point.point.x * 100}%`,
+                  top: `${point.point.y * 100}%`,
+                }}>
+                <div className="absolute bg-[#3B68FF] text-center text-white text-xs px-1 bottom-4 rounded-sm -translate-x-1/2 left-1/2">
+                  {point.label}
+                </div>
+                <div className="absolute w-4 h-4 bg-[#3B68FF] rounded-full border-white border-[2px] -translate-x-1/2 -translate-y-1/2"></div>
+              </div>
+            );
+          })}
+        {detectType === '3D bounding boxes' && linesAndLabels3D ? (
+          <>
+            {linesAndLabels3D[0].map((line, i) => (
+              <div
+                key={i}
+                className="absolute h-[2px] bg-[#3B68FF]"
+                style={{
+                  width: `${line.length}px`,
+                  transform: `translate(${line.start[0]}px, ${line.start[1]}px) rotate(${line.angle}rad)`,
+                  transformOrigin: '0 0',
+                }}></div>
+            ))}
+            {linesAndLabels3D[1].map((label, i) => (
+              <div
+                key={i}
+                className="absolute bg-[#3B68FF] text-white text-xs px-1"
+                style={{
+                  top: `${label.pos[1]}px`,
+                  left: `${label.pos[0]}px`,
+                  transform: 'translate(-50%, -50%)',
+                }}>
+                {label.label}
+              </div>
+            ))}
+          </>
+        ) : null}
+      </div>
+    </div>
+  );
+}
+
+function BoxMask({
+  box,
+  index,
+}: {
+  box: {
+    x: number;
+    y: number;
+    width: number;
+    height: number;
+    label: string;
+    imageData: string;
+  };
+  index: number;
+}) {
+  const canvasRef = useRef<HTMLCanvasElement | null>(null);
+  const rgb = segmentationColorsRgb[index % segmentationColorsRgb.length];
+
+  useEffect(() => {
+    if (canvasRef.current) {
+      const ctx = canvasRef.current.getContext('2d');
+      if (ctx) {
+        const image = new Image();
+        image.src = box.imageData;
+        image.onload = () => {
+          canvasRef.current!.width = image.width;
+          canvasRef.current!.height = image.height;
+          ctx.imageSmoothingEnabled = false;
+          ctx.drawImage(image, 0, 0);
+          const pixels = ctx.getImageData(0, 0, image.width, image.height);
+          const data = pixels.data;
+          for (let i = 0; i < data.length; i += 4) {
+            // alpha from mask
+            data[i + 3] = data[i];
+            // color from palette
+            data[i] = rgb[0];
+            data[i + 1] = rgb[1];
+            data[i + 2] = rgb[2];
+          }
+          ctx.putImageData(pixels, 0, 0);
+        };
+      }
+    }
+  }, [canvasRef, box.imageData]);
+
+  return (
+    <canvas
+      ref={canvasRef}
+      className="absolute top-0 left-0 w-full h-full"
+      style={{opacity: 0.5}}
+    />
+  );
+}

--- a/referenceImplementations/genini-spatial-understanding-demo/DetectTypeSelector.tsx
+++ b/referenceImplementations/genini-spatial-understanding-demo/DetectTypeSelector.tsx
@@ -1,0 +1,62 @@
+/**
+ * @license
+ * SPDX-License-Identifier: Apache-2.0
+*/
+/* tslint:disable */
+// Copyright 2024 Google LLC
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+
+//     https://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import {useAtom} from 'jotai';
+import {DetectTypeAtom, HoverEnteredAtom} from './atoms';
+import {DetectTypes} from './Types';
+
+export function DetectTypeSelector() {
+  return (
+    <div className="flex flex-col flex-shrink-0">
+      <div className="mb-3 uppercase">Give me:</div>
+      <div className="flex flex-col gap-3">
+        {[
+          '2D bounding boxes',
+          'Segmentation masks',
+          'Points',
+          '3D bounding boxes',
+        ].map((label) => (
+          <SelectOption key={label} label={label} />
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function SelectOption({label}: {label: string}) {
+  const [detectType, setDetectType] = useAtom(DetectTypeAtom);
+  const [, setHoverEntered] = useAtom(HoverEnteredAtom);
+  // const resetState = useResetState();
+
+  return (
+    <button
+      className="py-6 items-center bg-transparent text-center gap-3"
+      style={{
+        borderColor: detectType === label ? 'var(--accent-color)' : undefined,
+        backgroundColor:
+          detectType === label ? 'var(--border-color)' : undefined,
+      }}
+      onClick={() => {
+        setHoverEntered(false);
+        setDetectType(label as DetectTypes);
+      }}>
+      {label}
+    </button>
+  );
+}

--- a/referenceImplementations/genini-spatial-understanding-demo/ExampleImages.tsx
+++ b/referenceImplementations/genini-spatial-understanding-demo/ExampleImages.tsx
@@ -1,0 +1,48 @@
+/**
+ * @license
+ * SPDX-License-Identifier: Apache-2.0
+*/
+/* tslint:disable */
+// Copyright 2024 Google LLC
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+
+//     https://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import {useAtom} from 'jotai';
+import {ImageSrcAtom, IsUploadedImageAtom} from './atoms';
+import {imageOptions} from './consts';
+import {useResetState} from './hooks';
+
+export function ExampleImages() {
+  const [, setImageSrc] = useAtom(ImageSrcAtom);
+  const [, setIsUploadedImage] = useAtom(IsUploadedImageAtom);
+  const resetState = useResetState();
+  return (
+    <div className="flex flex-wrap items-start gap-3 shrink-0 w-[190px]">
+      {imageOptions.map((image) => (
+        <button
+          key={image}
+          className="p-0 w-[56px] h-[56px] relative overflow-hidden"
+          onClick={() => {
+            setIsUploadedImage(false);
+            setImageSrc(image);
+            resetState();
+          }}>
+          <img
+            src={image}
+            className="absolute left-0 top-0 w-full h-full object-cover"
+          />
+        </button>
+      ))}
+    </div>
+  );
+}

--- a/referenceImplementations/genini-spatial-understanding-demo/ExtraModeControls.tsx
+++ b/referenceImplementations/genini-spatial-understanding-demo/ExtraModeControls.tsx
@@ -1,0 +1,122 @@
+/**
+ * @license
+ * SPDX-License-Identifier: Apache-2.0
+*/
+/* tslint:disable */
+// Copyright 2024 Google LLC
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+
+//     https://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import {useAtom} from 'jotai';
+import {
+  BoundingBoxes2DAtom,
+  BoundingBoxes3DAtom,
+  BoundingBoxMasksAtom,
+  DetectTypeAtom,
+  DrawModeAtom,
+  FOVAtom,
+  HoveredBoxAtom,
+  LinesAtom,
+  PointsAtom,
+  ShareStream,
+} from './atoms';
+import {Palette} from './Palette';
+
+export function ExtraModeControls() {
+  const [, setBoundingBoxes2D] = useAtom(BoundingBoxes2DAtom);
+  const [, setBoundingBoxes3D] = useAtom(BoundingBoxes3DAtom);
+  const [, setBoundingBoxMasks] = useAtom(BoundingBoxMasksAtom);
+  const [stream, setStream] = useAtom(ShareStream);
+  const [detectType] = useAtom(DetectTypeAtom);
+  const [fov, setFoV] = useAtom(FOVAtom);
+  const [, setPoints] = useAtom(PointsAtom);
+  const [, _setHoveredBox] = useAtom(HoveredBoxAtom);
+  const [drawMode, setDrawMode] = useAtom(DrawModeAtom);
+  const [, setLines] = useAtom(LinesAtom);
+
+  const showExtraBar = stream || detectType === '3D bounding boxes';
+
+  return (
+    <>
+      {detectType === '3D bounding boxes' ? (
+        <div className="flex gap-3 px-3 py-3 items-center justify-center bg-[var(--accent-color)] text-[var(--bg-color)] text-center border-t">
+          <div className="text-lg">🚧</div> 3d bounding boxes is a preliminary
+          model capability. Use 2D bounding boxes for higher accuracy.
+        </div>
+      ) : null}
+      {drawMode ? (
+        <div className="flex gap-3 px-3 py-3 items-center justify-between border-t">
+          <div style={{width: 200}}></div>
+          <div className="grow flex justify-center">
+            <Palette />
+          </div>
+          <div className="flex gap-3">
+            <div className="flex gap-3">
+              <button
+                className="flex gap-3 text-sm secondary"
+                onClick={() => {
+                  setLines([]);
+                }}>
+                <div className="text-xs">🗑️</div>
+                Clear
+              </button>
+            </div>
+            <div className="flex gap-3">
+              <button
+                className="flex gap-3 secondary"
+                onClick={() => {
+                  setDrawMode(false);
+                }}>
+                <div className="text-sm">✅</div>
+                <div>Done</div>
+              </button>
+            </div>
+          </div>
+        </div>
+      ) : null}
+      {showExtraBar ? (
+        <div className="flex gap-3 px-3 py-3 border-t items-center justify-center">
+          {stream ? (
+            <button
+              className="flex gap-3 text-sm items-center secondary"
+              onClick={() => {
+                stream.getTracks().forEach((track) => track.stop());
+                setStream(null);
+                setBoundingBoxes2D([]);
+                setBoundingBoxes3D([]);
+                setBoundingBoxMasks([]);
+                setPoints([]);
+              }}>
+              <div className="text-xs">🔴</div>
+              <div className="whitespace-nowrap">Stop screenshare</div>
+            </button>
+          ) : null}
+          {detectType === '3D bounding boxes' ? (
+            <>
+              <div>FOV</div>
+              <input
+                className="w-full"
+                type="range"
+                min="30"
+                max="120"
+                value={fov}
+                onChange={(e) => setFoV(+e.target.value)}
+              />
+              <div>{fov}</div>
+            </>
+          ) : null}
+        </div>
+      ) : null}
+    </>
+  );
+}

--- a/referenceImplementations/genini-spatial-understanding-demo/Palette.tsx
+++ b/referenceImplementations/genini-spatial-understanding-demo/Palette.tsx
@@ -1,0 +1,57 @@
+/**
+ * @license
+ * SPDX-License-Identifier: Apache-2.0
+*/
+/* tslint:disable */
+// Copyright 2024 Google LLC
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+
+//     https://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import {useAtom} from 'jotai';
+import {ActiveColorAtom} from './atoms';
+import {colors} from './consts';
+
+export function Palette() {
+  const [activeColor, setActiveColor] = useAtom(ActiveColorAtom);
+  return (
+    <div
+      className="flex gap-2 pointer-events-auto"
+      onClick={(e) => {
+        e.stopPropagation();
+      }}>
+      {colors.map((color) => (
+        <div
+          className="w-7 h-7 rounded-full pointer-events-auto cursor-pointer relative"
+          style={{
+            background: color === activeColor ? 'transparent' : color,
+            border: color === activeColor ? '1px solid ' + color : 'none',
+            width: 24,
+            height: 24,
+          }}
+          onClick={(e) => {
+            e.stopPropagation();
+            setActiveColor(color);
+          }}>
+          <div
+            className="w-5 h-5 rounded-full absolute top-1/2 left-1/2 transform -translate-x-1/2 -translate-y-1/2"
+            style={{
+              width: 18,
+              height: 18,
+              background: color,
+            }}
+          />
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/referenceImplementations/genini-spatial-understanding-demo/Prompt.tsx
+++ b/referenceImplementations/genini-spatial-understanding-demo/Prompt.tsx
@@ -1,0 +1,465 @@
+/**
+ * @license
+ * SPDX-License-Identifier: Apache-2.0
+*/
+/* tslint:disable */
+// Copyright 2024 Google LLC
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+
+//     https://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import {GoogleGenAI} from '@google/genai';
+import {useAtom} from 'jotai';
+import getStroke from 'perfect-freehand';
+import {useState} from 'react';
+import {
+  BoundingBoxMasksAtom,
+  BoundingBoxes2DAtom,
+  BoundingBoxes3DAtom,
+  CustomPromptsAtom,
+  DetectTypeAtom,
+  HoverEnteredAtom,
+  ImageSrcAtom,
+  IsLoadingAtom,
+  LinesAtom,
+  PointsAtom,
+  PromptsAtom,
+  ShareStream,
+  TemperatureAtom,
+  VideoRefAtom,
+} from './atoms';
+import {lineOptions} from './consts';
+import {DetectTypes} from './Types';
+import {getSvgPathFromStroke, loadImage} from './utils';
+
+const ai = new GoogleGenAI({apiKey: process.env.GEMINI_API_KEY});
+export function Prompt() {
+  const [temperature, setTemperature] = useAtom(TemperatureAtom);
+  const [, setBoundingBoxes2D] = useAtom(BoundingBoxes2DAtom);
+  const [, setBoundingBoxes3D] = useAtom(BoundingBoxes3DAtom);
+  const [, setBoundingBoxMasks] = useAtom(BoundingBoxMasksAtom);
+  const [stream] = useAtom(ShareStream);
+  const [detectType] = useAtom(DetectTypeAtom);
+  const [, setPoints] = useAtom(PointsAtom);
+  const [, setHoverEntered] = useAtom(HoverEnteredAtom);
+  const [lines] = useAtom(LinesAtom);
+  const [videoRef] = useAtom(VideoRefAtom);
+  const [imageSrc] = useAtom(ImageSrcAtom);
+  const [showCustomPrompt] = useState(false);
+  const [targetPrompt, setTargetPrompt] = useState('items');
+  const [labelPrompt, setLabelPrompt] = useState('');
+  const [segmentationLanguage, setSegmentationLanguage] = useState('English');
+  const [showRawPrompt, setShowRawPrompt] = useState(false);
+
+  const [prompts, setPrompts] = useAtom(PromptsAtom);
+  const [customPrompts, setCustomPrompts] = useAtom(CustomPromptsAtom);
+  const [isLoading, setIsLoading] = useAtom(IsLoadingAtom);
+
+  const is2d = detectType === '2D bounding boxes';
+
+  const get2dPrompt = () =>
+    `Detect ${targetPrompt}, with no more than 20 items. Output a json list where each entry contains the 2D bounding box in "box_2d" and ${
+      labelPrompt || 'a text label'
+    } in "label".`;
+
+  const getSegmentationPrompt = () => {
+    const promptParts = prompts['Segmentation masks'];
+    const prefix = promptParts[0];
+    const items = promptParts[1]; // User-editable "items"
+    let suffix = promptParts[2];
+
+    const originalLabelInstruction =
+      ' text label in the key "label". Use descriptive labels.';
+
+    if (
+      segmentationLanguage &&
+      segmentationLanguage.trim() !== '' &&
+      segmentationLanguage.toLowerCase() !== 'english'
+    ) {
+      if (suffix.endsWith(originalLabelInstruction)) {
+        suffix = suffix.substring(
+          0,
+          suffix.length - originalLabelInstruction.length,
+        );
+      }
+      suffix += ` text label in language ${segmentationLanguage} in the key "label". Use descriptive labels in ${segmentationLanguage}. Ensure labels are in ${segmentationLanguage}.  DO NOT USE ENGLISH FOR LABELS.`;
+    }
+    return `${prefix} ${items}${suffix}`;
+  };
+
+  const getGenericPrompt = (type: DetectTypes) => {
+    if (!prompts[type] || prompts[type].length < 3)
+      return prompts[type]?.join(' ') || '';
+    const [p0, p1, p2] = prompts[type];
+    return `${p0} ${p1}${p2}`;
+  };
+
+  async function handleSend() {
+    setIsLoading(true);
+    try {
+      let activeDataURL;
+      const maxSize = 640;
+      const copyCanvas = document.createElement('canvas');
+      const ctx = copyCanvas.getContext('2d')!;
+
+      if (stream) {
+        // screenshare
+        const video = videoRef.current!;
+        const scale = Math.min(
+          maxSize / video.videoWidth,
+          maxSize / video.videoHeight,
+        );
+        copyCanvas.width = video.videoWidth * scale;
+        copyCanvas.height = video.videoHeight * scale;
+        ctx.drawImage(
+          video,
+          0,
+          0,
+          video.videoWidth * scale,
+          video.videoHeight * scale,
+        );
+      } else if (imageSrc) {
+        const image = await loadImage(imageSrc);
+        const scale = Math.min(maxSize / image.width, maxSize / image.height);
+        copyCanvas.width = image.width * scale;
+        copyCanvas.height = image.height * scale;
+        console.log(copyCanvas);
+        ctx.drawImage(image, 0, 0, image.width * scale, image.height * scale);
+      }
+      activeDataURL = copyCanvas.toDataURL('image/png');
+
+      if (lines.length > 0) {
+        for (const line of lines) {
+          const p = new Path2D(
+            getSvgPathFromStroke(
+              getStroke(
+                line[0].map(([x, y]) => [
+                  x * copyCanvas.width,
+                  y * copyCanvas.height,
+                  0.5,
+                ]),
+                lineOptions,
+              ),
+            ),
+          );
+          ctx.fillStyle = line[1];
+          ctx.fill(p);
+        }
+        activeDataURL = copyCanvas.toDataURL('image/png');
+      }
+
+      const prompt = prompts[detectType];
+
+      setHoverEntered(false);
+      const config: {
+        temperature: number;
+        thinkingConfig?: {thinkingBudget: number};
+      } = {
+        temperature,
+      };
+      let model = 'models/gemini-2.5-flash';
+      if (detectType === '3D bounding boxes') {
+        // 3D works better with 2.0 Flash.
+        model = 'models/gemini-2.0-flash';
+      } else {
+        // Disable thinking for 2.5 Flash, as recommended for spatial
+        // understanding tasks.
+        config['thinkingConfig'] = {thinkingBudget: 0};
+      }
+
+      let textPromptToSend = '';
+      if (is2d) {
+        textPromptToSend = get2dPrompt();
+      } else if (detectType === 'Segmentation masks') {
+        textPromptToSend = getSegmentationPrompt();
+      } else {
+        textPromptToSend = getGenericPrompt(detectType);
+      }
+      let response = (
+        await ai.models.generateContent({
+          model,
+          contents: [
+            {
+              role: 'user',
+              parts: [
+                {
+                  inlineData: {
+                    data: activeDataURL.replace('data:image/png;base64,', ''),
+                    mimeType: 'image/png',
+                  },
+                },
+                {text: textPromptToSend},
+              ],
+            },
+          ],
+          config,
+        })
+      ).text;
+
+      if (response.includes('```json')) {
+        response = response.split('```json')[1].split('```')[0];
+      }
+      const parsedResponse = JSON.parse(response);
+      if (detectType === '2D bounding boxes') {
+        const formattedBoxes = parsedResponse.map(
+          (box: {box_2d: [number, number, number, number]; label: string}) => {
+            const [ymin, xmin, ymax, xmax] = box.box_2d;
+            return {
+              x: xmin / 1000,
+              y: ymin / 1000,
+              width: (xmax - xmin) / 1000,
+              height: (ymax - ymin) / 1000,
+              label: box.label,
+            };
+          },
+        );
+        setHoverEntered(false);
+        setBoundingBoxes2D(formattedBoxes);
+      } else if (detectType === 'Points') {
+        const formattedPoints = parsedResponse.map(
+          (point: {point: [number, number]; label: string}) => {
+            return {
+              point: {
+                x: point.point[1] / 1000,
+                y: point.point[0] / 1000,
+              },
+              label: point.label,
+            };
+          },
+        );
+        setPoints(formattedPoints);
+      } else if (detectType === 'Segmentation masks') {
+        const formattedBoxes = parsedResponse.map(
+          (box: {
+            box_2d: [number, number, number, number];
+            label: string;
+            mask: ImageData;
+          }) => {
+            const [ymin, xmin, ymax, xmax] = box.box_2d;
+            return {
+              x: xmin / 1000,
+              y: ymin / 1000,
+              width: (xmax - xmin) / 1000,
+              height: (ymax - ymin) / 1000,
+              label: box.label,
+              imageData: box.mask,
+            };
+          },
+        );
+        setHoverEntered(false);
+        // sort largest to smallest
+        const sortedBoxes = formattedBoxes.sort(
+          (a: any, b: any) => b.width * b.height - a.width * a.height,
+        );
+        setBoundingBoxMasks(sortedBoxes);
+      } else {
+        const formattedBoxes = parsedResponse.map(
+          (box: {
+            box_3d: [
+              number,
+              number,
+              number,
+              number,
+              number,
+              number,
+              number,
+              number,
+              number,
+            ];
+            label: string;
+          }) => {
+            const center = box.box_3d.slice(0, 3);
+            const size = box.box_3d.slice(3, 6);
+            const rpy = box.box_3d
+              .slice(6)
+              .map((x: number) => (x * Math.PI) / 180);
+            return {
+              center,
+              size,
+              rpy,
+              label: box.label,
+            };
+          },
+        );
+        setBoundingBoxes3D(formattedBoxes);
+      }
+    } finally {
+      setIsLoading(false);
+    }
+  }
+
+  return (
+    <div className="flex grow flex-col gap-3">
+      <div className="flex justify-between items-center">
+        <div className="uppercase">
+          Prompt:{' '}
+          {detectType === '3D bounding boxes'
+            ? 'Gemini 2.0 Flash'
+            : 'Gemini 2.5 Flash (no thinking)'}
+        </div>
+        <label className="flex gap-2 select-none">
+          <input
+            type="checkbox"
+            checked={showRawPrompt}
+            onChange={() => setShowRawPrompt(!showRawPrompt)}
+            disabled={isLoading}
+          />
+          <div>show raw prompt</div>
+        </label>
+      </div>
+      <div className="w-full flex flex-col">
+        {showCustomPrompt ? (
+          <textarea
+            className="w-full bg-[var(--input-color)] rounded-lg resize-none p-4"
+            value={customPrompts[detectType]}
+            onChange={(e) => {
+              const value = e.target.value;
+              const newPrompts = {...customPrompts};
+              newPrompts[detectType] = value;
+              setCustomPrompts(newPrompts);
+            }}
+            onKeyDown={(e) => {
+              if (e.key === 'Enter' && !isLoading) {
+                e.preventDefault();
+                handleSend();
+              }
+            }}
+            disabled={isLoading}
+          />
+        ) : showRawPrompt ? (
+          <div className="mb-2 text-[var(--text-color-secondary)]">
+            {is2d
+              ? get2dPrompt()
+              : detectType === 'Segmentation masks'
+                ? getSegmentationPrompt()
+                : getGenericPrompt(detectType)}
+          </div>
+        ) : (
+          <div className="flex flex-col gap-2">
+            <div>{is2d ? 'Detect' : prompts[detectType][0]}</div>
+            <textarea
+              className="w-full bg-[var(--input-color)] rounded-lg resize-none p-4"
+              placeholder="What kind of things do you want to detect?"
+              rows={1}
+              value={is2d ? targetPrompt : prompts[detectType][1]}
+              onChange={(e) => {
+                if (is2d) {
+                  setTargetPrompt(e.target.value);
+                } else {
+                  const value = e.target.value;
+                  const newPromptsState = {...prompts};
+                  if (!newPromptsState[detectType])
+                    newPromptsState[detectType] = ['', '', ''];
+                  newPromptsState[detectType][1] = value;
+                  setPrompts(newPromptsState);
+                }
+              }}
+              onKeyDown={(e) => {
+                if (e.key === 'Enter' && !isLoading) {
+                  e.preventDefault();
+                  handleSend();
+                }
+              }}
+              disabled={isLoading}
+            />
+            {detectType === 'Segmentation masks' && (
+              <>
+                <div className="mt-1">
+                  Output labels in language: (e.g. Deutsch, Français, Español,
+                  中文)
+                </div>
+                <textarea
+                  aria-label="Language for segmentation labels"
+                  className="w-full bg-[var(--input-color)] rounded-lg resize-none p-4"
+                  rows={1}
+                  placeholder="e.g., Deutsch, Français, Español"
+                  value={segmentationLanguage}
+                  onChange={(e) => setSegmentationLanguage(e.target.value)}
+                  onKeyDown={(e) => {
+                    if (e.key === 'Enter' && !isLoading) {
+                      e.preventDefault();
+                      handleSend();
+                    }
+                  }}
+                  disabled={isLoading}
+                />
+              </>
+            )}
+            {is2d && (
+              <>
+                <div>Label each one with: (optional)</div>
+                <textarea
+                  className="w-full bg-[var(--input-color)] rounded-lg resize-none p-4"
+                  rows={1}
+                  placeholder="How do you want to label the things?"
+                  value={labelPrompt}
+                  onChange={(e) => setLabelPrompt(e.target.value)}
+                  onKeyDown={(e) => {
+                    if (e.key === 'Enter' && !isLoading) {
+                      e.preventDefault();
+                      handleSend();
+                    }
+                  }}
+                  disabled={isLoading}
+                />
+              </>
+            )}
+          </div>
+        )}
+      </div>
+      <div className="flex justify-between gap-3">
+        <button
+          className={`bg-[#3B68FF] px-12 !text-white !border-none flex items-center justify-center ${isLoading ? 'opacity-50 cursor-not-allowed' : ''}`}
+          onClick={handleSend}
+          disabled={isLoading}>
+          {isLoading ? (
+            <>
+              <svg
+                className="animate-spin -ml-1 mr-3 h-5 w-5 text-white"
+                xmlns="http://www.w3.org/2000/svg"
+                fill="none"
+                viewBox="0 0 24 24">
+                <circle
+                  className="opacity-25"
+                  cx="12"
+                  cy="12"
+                  r="10"
+                  stroke="currentColor"
+                  strokeWidth="4"></circle>
+                <path
+                  className="opacity-75"
+                  fill="currentColor"
+                  d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
+              </svg>
+              Sending...
+            </>
+          ) : (
+            'Send'
+          )}
+        </button>
+        <label className="flex items-center gap-2">
+          temperature:
+          <input
+            type="range"
+            min="0"
+            max="2"
+            step="0.05"
+            value={temperature}
+            onChange={(e) => setTemperature(Number(e.target.value))}
+            disabled={isLoading}
+          />
+          {temperature.toFixed(2)}
+        </label>
+      </div>
+    </div>
+  );
+}

--- a/referenceImplementations/genini-spatial-understanding-demo/README.md
+++ b/referenceImplementations/genini-spatial-understanding-demo/README.md
@@ -1,0 +1,20 @@
+<div align="center">
+<img width="1200" height="475" alt="GHBanner" src="https://github.com/user-attachments/assets/0aa67016-6eaf-458a-adb2-6e31a0763ed6" />
+</div>
+
+# Run and deploy your AI Studio app
+
+This contains everything you need to run your app locally.
+
+View your app in AI Studio: https://ai.studio/apps/drive/17FarXprR3ZA9Rz1XdQmhyGiFwTqu-gu0
+
+## Run Locally
+
+**Prerequisites:**  Node.js
+
+
+1. Install dependencies:
+   `npm install`
+2. Set the `GEMINI_API_KEY` in [.env.local](.env.local) to your Gemini API key
+3. Run the app:
+   `npm run dev`

--- a/referenceImplementations/genini-spatial-understanding-demo/ScreenshareButton.tsx
+++ b/referenceImplementations/genini-spatial-understanding-demo/ScreenshareButton.tsx
@@ -1,0 +1,41 @@
+/**
+ * @license
+ * SPDX-License-Identifier: Apache-2.0
+*/
+/* tslint:disable */
+// Copyright 2024 Google LLC
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+
+//     https://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import {useAtom} from 'jotai';
+import {ShareStream} from './atoms';
+import {useResetState} from './hooks';
+
+export function ScreenshareButton() {
+  const [, setStream] = useAtom(ShareStream);
+  const resetState = useResetState();
+
+  return (
+    <button
+      className="button flex gap-3 justify-center items-center"
+      onClick={() => {
+        resetState();
+        navigator.mediaDevices.getDisplayMedia({video: true}).then((stream) => {
+          setStream(stream);
+        });
+      }}>
+      <div className="text-lg">🖥️</div>
+      <div>Screenshare</div>
+    </button>
+  );
+}

--- a/referenceImplementations/genini-spatial-understanding-demo/SideControls.tsx
+++ b/referenceImplementations/genini-spatial-understanding-demo/SideControls.tsx
@@ -1,0 +1,76 @@
+/**
+ * @license
+ * SPDX-License-Identifier: Apache-2.0
+*/
+/* tslint:disable */
+// Copyright 2024 Google LLC
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+
+//     https://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import {useAtom} from 'jotai';
+import {
+  BumpSessionAtom,
+  DrawModeAtom,
+  ImageSentAtom,
+  ImageSrcAtom,
+  IsUploadedImageAtom,
+} from './atoms';
+import {useResetState} from './hooks';
+import {ScreenshareButton} from './ScreenshareButton';
+
+export function SideControls() {
+  const [, setImageSrc] = useAtom(ImageSrcAtom);
+  const [drawMode, setDrawMode] = useAtom(DrawModeAtom);
+  const [, setIsUploadedImage] = useAtom(IsUploadedImageAtom);
+  const [, setBumpSession] = useAtom(BumpSessionAtom);
+  const [, setImageSent] = useAtom(ImageSentAtom);
+  const resetState = useResetState();
+
+  return (
+    <div className="flex flex-col gap-3">
+      <label className="flex items-center button bg-[#3B68FF] px-12 !text-white !border-none">
+        <input
+          className="hidden"
+          type="file"
+          accept=".jpg, .jpeg, .png, .webp"
+          onChange={(e) => {
+            const file = e.target.files?.[0];
+            if (file) {
+              const reader = new FileReader();
+              reader.onload = (e) => {
+                resetState();
+                setImageSrc(e.target?.result as string);
+                setIsUploadedImage(true);
+                setImageSent(false);
+                setBumpSession((prev) => prev + 1);
+              };
+              reader.readAsDataURL(file);
+            }
+          }}
+        />
+        <div>Upload an image</div>
+      </label>
+      <div className="hidden">
+        <button
+          className="button flex gap-3 justify-center items-center"
+          onClick={() => {
+            setDrawMode(!drawMode);
+          }}>
+          <div className="text-lg"> 🎨</div>
+          <div>Draw on image</div>
+        </button>
+        <ScreenshareButton />
+      </div>
+    </div>
+  );
+}

--- a/referenceImplementations/genini-spatial-understanding-demo/TopBar.tsx
+++ b/referenceImplementations/genini-spatial-understanding-demo/TopBar.tsx
@@ -1,0 +1,66 @@
+/**
+ * @license
+ * SPDX-License-Identifier: Apache-2.0
+*/
+/* tslint:disable */
+// Copyright 2024 Google LLC
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+
+//     https://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import {useAtom} from 'jotai';
+import {DetectTypeAtom, HoverEnteredAtom, RevealOnHoverModeAtom} from './atoms';
+import {useResetState} from './hooks';
+
+export function TopBar() {
+  const resetState = useResetState();
+  const [revealOnHover, setRevealOnHoverMode] = useAtom(RevealOnHoverModeAtom);
+  const [detectType] = useAtom(DetectTypeAtom);
+  const [, setHoverEntered] = useAtom(HoverEnteredAtom);
+
+  return (
+    <div className="flex w-full items-center px-3 py-2 border-b justify-between">
+      <div className="flex gap-3 items-center">
+        <button
+          onClick={() => {
+            resetState();
+          }}
+          className="!p-0 !border-none underline bg-transparent"
+          style={{
+            minHeight: '0',
+          }}>
+          <div>Reset session</div>
+        </button>
+      </div>
+      <div className="flex gap-3 items-center">
+        {detectType === '2D bounding boxes' ||
+        detectType === 'Segmentation masks' ? (
+          <div>
+            <label className="flex items-center gap-2 px-3 select-none whitespace-nowrap">
+              <input
+                type="checkbox"
+                checked={revealOnHover}
+                onChange={(e) => {
+                  if (e.target.checked) {
+                    setHoverEntered(false);
+                  }
+                  setRevealOnHoverMode(e.target.checked);
+                }}
+              />
+              <div>reveal on hover</div>
+            </label>
+          </div>
+        ) : null}
+      </div>
+    </div>
+  );
+}

--- a/referenceImplementations/genini-spatial-understanding-demo/Types.tsx
+++ b/referenceImplementations/genini-spatial-understanding-demo/Types.tsx
@@ -1,0 +1,48 @@
+/**
+ * @license
+ * SPDX-License-Identifier: Apache-2.0
+*/
+/* tslint:disable */
+// Copyright 2024 Google LLC
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+
+//     https://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+export type DetectTypes =
+  | '2D bounding boxes'
+  | 'Segmentation masks'
+  | '3D bounding boxes'
+  | 'Points';
+
+export type BoundingBox2DType = {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+  label: string;
+};
+
+export type BoundingBoxMaskType = {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+  label: string;
+  imageData: string;
+};
+
+export type BoundingBox3DType = {
+  center: [number, number, number];
+  size: [number, number, number];
+  rpy: [number, number, number];
+  label: string;
+};

--- a/referenceImplementations/genini-spatial-understanding-demo/atoms.tsx
+++ b/referenceImplementations/genini-spatial-understanding-demo/atoms.tsx
@@ -1,0 +1,95 @@
+/**
+ * @license
+ * SPDX-License-Identifier: Apache-2.0
+*/
+/* tslint:disable */
+// Copyright 2024 Google LLC
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+
+//     https://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import {atom} from 'jotai';
+import {
+  colors,
+  defaultPromptParts,
+  defaultPrompts,
+  imageOptions,
+} from './consts';
+import {
+  BoundingBox2DType,
+  BoundingBox3DType,
+  BoundingBoxMaskType,
+  DetectTypes,
+} from './Types';
+
+export const ImageSrcAtom = atom<string | null>(imageOptions[0]);
+
+export const ImageSentAtom = atom(false);
+
+export const BoundingBoxes2DAtom = atom<BoundingBox2DType[]>([]);
+
+export const PromptsAtom = atom<Record<DetectTypes, string[]>>({
+  ...defaultPromptParts,
+});
+export const CustomPromptsAtom = atom<Record<DetectTypes, string>>({
+  ...defaultPrompts,
+});
+
+export type PointingType = {
+  point: {
+    x: number;
+    y: number;
+  };
+  label: string;
+};
+
+export const RevealOnHoverModeAtom = atom<boolean>(true);
+
+export const FOVAtom = atom<number>(60);
+
+export const BoundingBoxes3DAtom = atom<BoundingBox3DType[]>([]);
+
+export const BoundingBoxMasksAtom = atom<BoundingBoxMaskType[]>([]);
+
+export const PointsAtom = atom<PointingType[]>([]);
+
+// export const PromptAtom = atom<string>("main objects");
+
+export const TemperatureAtom = atom<number>(0.5);
+
+export const ShareStream = atom<MediaStream | null>(null);
+
+export const DrawModeAtom = atom<boolean>(false);
+
+export const DetectTypeAtom = atom<DetectTypes>('2D bounding boxes');
+
+export const LinesAtom = atom<[[number, number][], string][]>([]);
+
+export const JsonModeAtom = atom(false);
+
+export const ActiveColorAtom = atom(colors[6]);
+
+export const HoverEnteredAtom = atom(false);
+
+export const HoveredBoxAtom = atom<number | null>(null);
+
+export const VideoRefAtom = atom<{current: HTMLVideoElement | null}>({
+  current: null,
+});
+
+export const InitFinishedAtom = atom(true);
+
+export const BumpSessionAtom = atom(0);
+
+export const IsUploadedImageAtom = atom(false);
+
+export const IsLoadingAtom = atom(false);

--- a/referenceImplementations/genini-spatial-understanding-demo/consts.tsx
+++ b/referenceImplementations/genini-spatial-understanding-demo/consts.tsx
@@ -1,0 +1,120 @@
+/**
+ * @license
+ * SPDX-License-Identifier: Apache-2.0
+*/
+/* tslint:disable */
+// Copyright 2024 Google LLC
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+
+//     https://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+export const colors = [
+  'rgb(0, 0, 0)',
+  'rgb(255, 255, 255)',
+  'rgb(213, 40, 40)',
+  'rgb(250, 123, 23)',
+  'rgb(240, 186, 17)',
+  'rgb(8, 161, 72)',
+  'rgb(26, 115, 232)',
+  'rgb(161, 66, 244)',
+];
+
+function hexToRgb(hex: string) {
+  const r = parseInt(hex.substring(1, 3), 16);
+  const g = parseInt(hex.substring(3, 5), 16);
+  const b = parseInt(hex.substring(5, 7), 16);
+  return [r, g, b];
+}
+
+export const segmentationColors = [
+  '#E6194B',
+  '#3C89D0',
+  '#3CB44B',
+  '#FFE119',
+  '#911EB4',
+  '#42D4F4',
+  '#F58231',
+  '#F032E6',
+  '#BFEF45',
+  '#469990',
+];
+export const segmentationColorsRgb = segmentationColors.map((c) => hexToRgb(c));
+
+export const imageOptions: string[] = await Promise.all(
+  [
+    'origami.jpg',
+    'pumpkins.jpg',
+    'clock.jpg',
+    'socks.jpg',
+    'breakfast.jpg',
+    'cat.jpg',
+    'spill.jpg',
+    'fruit.jpg',
+    'baklava.jpg',
+  ].map(async (i) =>
+    URL.createObjectURL(
+      await (
+        await fetch(
+          `https://www.gstatic.com/aistudio/starter-apps/bounding-box/${i}`,
+        )
+      ).blob(),
+    ),
+  ),
+);
+
+export const lineOptions = {
+  size: 8,
+  thinning: 0,
+  smoothing: 0,
+  streamline: 0,
+  simulatePressure: false,
+};
+
+export const defaultPromptParts = {
+  '2D bounding boxes': [
+    'Show me the positions of',
+    'items',
+    'as a JSON list. Do not return masks. Limit to 25 items.',
+  ],
+  'Segmentation masks': [
+    `Give the segmentation masks for`,
+    'all objects',
+    `. Output a JSON list of segmentation masks where each entry contains the 2D bounding box in the key "box_2d", the segmentation mask in key "mask", and the text label in the key "label". Use descriptive labels.`,
+  ],
+  '3D bounding boxes': [
+    'Output in json. Detect the 3D bounding boxes of ',
+    'items',
+    ', output no more than 10 items. Return a list where each entry contains the object name in "label" and its 3D bounding box in "box_3d".',
+  ],
+  Points: [
+    'Point to the',
+    'items',
+    ' with no more than 10 items. The answer should follow the json format: [{"point": <point>, "label": <label1>}, ...]. The points are in [y, x] format normalized to 0-1000.',
+  ],
+};
+
+export const defaultPrompts = {
+  '2D bounding boxes': defaultPromptParts['2D bounding boxes'].join(' '),
+  '3D bounding boxes': defaultPromptParts['3D bounding boxes'].join(' '),
+  'Segmentation masks': defaultPromptParts['Segmentation masks'].join(''),
+  Points: defaultPromptParts.Points.join(' '),
+};
+
+const safetyLevel = 'only_high';
+
+export const safetySettings = new Map();
+
+safetySettings.set('harassment', safetyLevel);
+safetySettings.set('hate_speech', safetyLevel);
+safetySettings.set('sexually_explicit', safetyLevel);
+safetySettings.set('dangerous_content', safetyLevel);
+safetySettings.set('civic_integrity', safetyLevel);

--- a/referenceImplementations/genini-spatial-understanding-demo/hooks.tsx
+++ b/referenceImplementations/genini-spatial-understanding-demo/hooks.tsx
@@ -1,0 +1,46 @@
+/**
+ * @license
+ * SPDX-License-Identifier: Apache-2.0
+*/
+/* tslint:disable */
+// Copyright 2024 Google LLC
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+
+//     https://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import {useAtom} from 'jotai';
+import {
+  BoundingBoxes2DAtom,
+  BoundingBoxes3DAtom,
+  BoundingBoxMasksAtom,
+  BumpSessionAtom,
+  ImageSentAtom,
+  PointsAtom,
+} from './atoms';
+
+export function useResetState() {
+  const [, setImageSent] = useAtom(ImageSentAtom);
+  const [, setBoundingBoxes2D] = useAtom(BoundingBoxes2DAtom);
+  const [, setBoundingBoxes3D] = useAtom(BoundingBoxes3DAtom);
+  const [, setBoundingBoxMasks] = useAtom(BoundingBoxMasksAtom);
+  const [, setPoints] = useAtom(PointsAtom);
+  const [, setBumpSession] = useAtom(BumpSessionAtom);
+
+  return () => {
+    setImageSent(false);
+    setBoundingBoxes2D([]);
+    setBoundingBoxes3D([]);
+    setBoundingBoxMasks([]);
+    setBumpSession((prev) => prev + 1);
+    setPoints([]);
+  };
+}

--- a/referenceImplementations/genini-spatial-understanding-demo/index.css
+++ b/referenceImplementations/genini-spatial-understanding-demo/index.css
@@ -1,0 +1,157 @@
+@import url("https://fonts.googleapis.com/css2?family=Space+Mono:ital,wght@0,400;0,700;1,400;1,700&display=swap");
+
+html,
+body,
+#root {
+  height: 100%;
+  margin: 0;
+}
+
+body {
+  font-size: 13px;
+  background-color: var(--bg-color);
+  color: var(--text-color-primary);
+}
+
+input, select {
+  accent-color: var(--accent-color);
+}
+
+input[type="text"],
+textarea {
+  color: var(--text-color-primary);
+  border: 1px solid var(--border-color);
+}
+
+input[type="text"]:focus,
+textarea:focus {
+  border-color: var(--accent-color);
+  outline: none;
+}
+
+.border,
+.border-l,
+.border-t,
+.border-b,
+.border-r {
+  border-color: var(--border-color);
+}
+
+.hide-box .bbox {
+  opacity: 0;
+  z-index: -1;
+}
+.hide-box .bbox.reveal {
+  opacity: 1;
+  z-index: 1;
+}
+
+:root {
+  --bg-color: #F3F3F6;
+  --accent-color: #2872E3;
+  --border-color: #C6C6C9;
+  --box-color: #141619;
+  --text-color-primary: #1E1E1E;
+  --text-color-secondary: #888D8F;
+  --text-size-large: 18px;
+  --text-size-medium: 14px;
+  --text-size-small: 11px;
+  --box-radius: 8px;
+  --input-color: #F9F9FC;
+  font-family: "Space Mono", monospace;
+  font-weight: 400;
+  font-size: 14px;
+  color: var(--text-color-primary);
+  background-color: var(--bg-color);
+}
+
+.dark {
+  --bg-color: #1C1F21;
+  --accent-color: #7FBBFF;
+  --border-color: #37393c;
+  --box-color: #141619;
+  --text-color-primary: #fff;
+  --text-color-secondary: #8c8d8e;
+  --input-color: #404547;
+  color: var(--text-color-primary);
+  background-color: var(--bg-color);
+  color-scheme: dark;
+}
+
+main {
+  max-width: 1000px;
+  margin: 0 auto;
+}
+
+button, .button {
+  appearance: none;
+  cursor: pointer;
+  font-family: inherit;
+  font-size: inherit;
+  font-weight: inherit;
+  color: var(--text-color-primary);
+  border: 1px solid var(--border-color);
+  padding: 14px 20px;
+  border-radius: var(--box-radius);
+  min-height: 56px;
+}
+
+button.secondary {
+  padding: 0px 16px;
+  min-height: 32px;
+  display: flex;
+  align-items: center;
+}
+
+button:hover, .button:hover {
+  border-color: var(--accent-color);
+}
+
+a {
+  cursor: pointer;
+  color: var(--text-color-primary);
+  text-decoration: underline var(--accent-color);
+}
+
+a:hover {
+  text-decoration-color: var(--text-color-primary);
+}
+
+input[type="text"] {
+  appearance: none;
+  font-family: inherit;
+  font-size: inherit;
+  font-weight: inherit;
+  color: var(--text-color-primary);
+  border: none;
+  padding: 14px 18px;
+}
+
+input[type="text"]::placeholder {
+  color: var(--text-color-secondary);
+}
+
+/* input:focus {
+  outline: none;
+} */
+
+input[type="range"] {
+  accent-color: var(--accent-color);
+}
+
+
+.box {
+  border-radius: var(--box-radius);
+  background: var(--box-color);
+  padding: 28px 42px;
+  font-size: var(--text-size-large);
+  margin: 30px 0;
+}
+
+.box-caption {
+  color: var(--bg-color);
+  background: var(--accent-color);
+  border-radius: var(--box-radius);
+  padding: 14px 28px;
+  max-width: 340px;
+}

--- a/referenceImplementations/genini-spatial-understanding-demo/index.html
+++ b/referenceImplementations/genini-spatial-understanding-demo/index.html
@@ -1,0 +1,27 @@
+<!doctype html>
+<html lang="en" class="dark">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>AIS Spatial Applet</title>
+    <script type="importmap">
+      {
+        "imports": {
+          "@google/genai": "https://esm.sh/@google/genai@^0.7.0",
+          "@tailwindcss/browser": "https://esm.sh/@tailwindcss/browser@^4.0.17",
+          "jotai": "https://esm.sh/jotai@^2.10.0",
+          "perfect-freehand": "https://esm.sh/perfect-freehand@^1.2.2",
+          "react": "https://esm.sh/react@^19.0.0",
+          "react/": "https://esm.sh/react@^19.0.0/",
+          "react-dom/": "https://esm.sh/react-dom@^19.0.0/",
+          "react-resize-detector": "https://esm.sh/react-resize-detector@^12.0.2"
+        }
+      }
+    </script>
+  <link rel="stylesheet" href="/index.css">
+</head>
+  <body>
+    <div id="root"></div>
+  <script type="module" src="/index.tsx"></script>
+</body>
+</html>

--- a/referenceImplementations/genini-spatial-understanding-demo/index.tsx
+++ b/referenceImplementations/genini-spatial-understanding-demo/index.tsx
@@ -1,0 +1,30 @@
+/**
+ * @license
+ * SPDX-License-Identifier: Apache-2.0
+*/
+/* tslint:disable */
+// Copyright 2024 Google LLC
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+
+//     https://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import '@tailwindcss/browser';
+
+import {StrictMode} from 'react';
+import {createRoot} from 'react-dom/client';
+import App from './App';
+
+createRoot(document.getElementById('root')!).render(
+  <StrictMode>
+    <App />
+  </StrictMode>,
+);

--- a/referenceImplementations/genini-spatial-understanding-demo/metadata.json
+++ b/referenceImplementations/genini-spatial-understanding-demo/metadata.json
@@ -1,0 +1,5 @@
+{
+  "name": "Copy of Spatial Understanding",
+  "description": "Unlock Gemini's vision! Detect objects in images or screenshares with interactive 2D/3D bounding boxes and points.",
+  "requestFramePermissions": []
+}

--- a/referenceImplementations/genini-spatial-understanding-demo/package.json
+++ b/referenceImplementations/genini-spatial-understanding-demo/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "copy-of-spatial-understanding",
+  "private": true,
+  "version": "0.0.0",
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "@google/genai": "^0.7.0",
+    "@tailwindcss/browser": "^4.0.17",
+    "jotai": "^2.10.0",
+    "perfect-freehand": "^1.2.2",
+    "react": "^19.0.0",
+    "react-dom": "^19.0.0",
+    "react-resize-detector": "^12.0.2"
+  },
+  "devDependencies": {
+    "@types/node": "^22.14.0",
+    "@vitejs/plugin-react": "^5.0.0",
+    "typescript": "~5.8.2",
+    "vite": "^6.2.0"
+  }
+}

--- a/referenceImplementations/genini-spatial-understanding-demo/tsconfig.json
+++ b/referenceImplementations/genini-spatial-understanding-demo/tsconfig.json
@@ -1,0 +1,29 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "experimentalDecorators": true,
+    "useDefineForClassFields": false,
+    "module": "ESNext",
+    "lib": [
+      "ES2022",
+      "DOM",
+      "DOM.Iterable"
+    ],
+    "skipLibCheck": true,
+    "types": [
+      "node"
+    ],
+    "moduleResolution": "bundler",
+    "isolatedModules": true,
+    "moduleDetection": "force",
+    "allowJs": true,
+    "jsx": "react-jsx",
+    "paths": {
+      "@/*": [
+        "./*"
+      ]
+    },
+    "allowImportingTsExtensions": true,
+    "noEmit": true
+  }
+}

--- a/referenceImplementations/genini-spatial-understanding-demo/utils.tsx
+++ b/referenceImplementations/genini-spatial-understanding-demo/utils.tsx
@@ -1,0 +1,57 @@
+/**
+ * @license
+ * SPDX-License-Identifier: Apache-2.0
+*/
+/* tslint:disable */
+// Copyright 2024 Google LLC
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+
+//     https://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+export function getSvgPathFromStroke(stroke: number[][]) {
+  if (!stroke.length) return '';
+
+  const d = stroke.reduce(
+    (acc, [x0, y0], i, arr) => {
+      const [x1, y1] = arr[(i + 1) % arr.length];
+      acc.push(x0, y0, (x0 + x1) / 2, (y0 + y1) / 2);
+      return acc;
+    },
+    ['M', ...stroke[0], 'Q'],
+  );
+
+  d.push('Z');
+  return d.join(' ');
+}
+
+export function loadImage(src: string) {
+  return new Promise<HTMLImageElement>((resolve, reject) => {
+    const img = new Image();
+    img.src = src;
+    img.onload = () => resolve(img);
+    img.onerror = reject;
+  });
+}
+
+export function hash(): Record<string, string> {
+  const hashVal = window.location.hash.substring(1);
+  const params: Record<string, string> = {};
+  if (hashVal) {
+    hashVal.split('&').forEach((hk) => {
+      const temp = hk.split('=', 2); // Split into at most 2 parts.
+      if (temp[0]) {
+        params[temp[0]] = temp[1] ? decodeURIComponent(temp[1]) : '';
+      }
+    });
+  }
+  return params;
+}

--- a/referenceImplementations/genini-spatial-understanding-demo/vite.config.ts
+++ b/referenceImplementations/genini-spatial-understanding-demo/vite.config.ts
@@ -1,0 +1,23 @@
+import path from 'path';
+import { defineConfig, loadEnv } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig(({ mode }) => {
+    const env = loadEnv(mode, '.', '');
+    return {
+      server: {
+        port: 3000,
+        host: '0.0.0.0',
+      },
+      plugins: [react()],
+      define: {
+        'process.env.API_KEY': JSON.stringify(env.GEMINI_API_KEY),
+        'process.env.GEMINI_API_KEY': JSON.stringify(env.GEMINI_API_KEY)
+      },
+      resolve: {
+        alias: {
+          '@': path.resolve(__dirname, '.'),
+        }
+      }
+    };
+});

--- a/src/aec-schema.js
+++ b/src/aec-schema.js
@@ -7,7 +7,7 @@ Return a JSON object with an "items" array (maximum 20 entries). Each item must 
 - "category": one of "object", "facility_asset", "safety_issue", "progress" (use the best fit for the detection).
 - "confidence": detection confidence between 0 and 1.
 - "box_2d": bounding box as [ymin, xmin, ymax, xmax] normalized 0-1000 with a top-left origin.
-- "mask": optional base64-encoded PNG segmentation mask aligned to the same region (omit when unavailable).
+- "mask": optional base64-encoded PNG segmentation mask aligned to the same region.
 - Optional context objects when relevant:
   - "safety": { "isViolation": boolean?, "severity": "low"|"medium"|"high"?, "rule": string? }
   - "progress": { "phase": string?, "percentComplete": number?, "notes": string? }

--- a/src/aec-schema.js
+++ b/src/aec-schema.js
@@ -1,16 +1,20 @@
 /* istanbul ignore file */
 
 export const AEC_PROMPT = `
-Detect the most relevant objects, equipment, safety issues, and facility assets in this construction/AEC image.
-Return a compact JSON object with an "items" array where each item includes:
-- "label": descriptive text label
-- "box_2d": bounding box as [ymin, xmin, ymax, xmax] normalized 0-1000
-- "mask": optional base64-encoded PNG segmentation mask when segmentation data is available
-- "points": optional array of key points as [y, x] pairs normalized 0-1000
-- "category": one of "object", "safety_issue", "facility_asset", "progress"
-- "confidence": 0-1 confidence score
+Detect the most relevant objects, equipment, safety issues, facility assets, and progress indicators in this construction/AEC image.
+Return a JSON object with an "items" array (maximum 20 entries). Each item must include:
+- "labels": array of strings ordered from most specific to most general (e.g., ["bag of cement from Company X", "cement", "building material"]). Always include at least one label.
+- "category": one of "object", "facility_asset", "safety_issue", "progress" (use the best fit for the detection).
+- "confidence": detection confidence between 0 and 1.
+- "box_2d": bounding box as [ymin, xmin, ymax, xmax] normalized 0-1000 with a top-left origin.
+- "mask": optional base64-encoded PNG segmentation mask aligned to the same region (omit when unavailable).
+- Optional context objects when relevant:
+  - "safety": { "isViolation": boolean?, "severity": "low"|"medium"|"high"?, "rule": string? }
+  - "progress": { "phase": string?, "percentComplete": number?, "notes": string? }
+  - "attributes": array of { "name": string, "valueStr"?: string, "valueNum"?: number, "valueBool"?: boolean, "unit"?: string }
+  - "relationships": array of { "type": string, "targetId": string }
 
-Return at most 25 items, prioritizing the highest-confidence detections. Only include masks or points when the model provides them. Output ONLY JSON, no prose, no code fences.
+Do not return polygons or keypoints. Use the labels array for both specific names and broader searchable terms instead of separate name/description fields. Include an optional "global_insights" array for whole-image observations following the same labeling approach (labels array, category, confidence, description, optional metrics). Output ONLY JSON with no prose or code fences.
 `.trim();
 
 export const RESPONSE_SCHEMA = {
@@ -21,23 +25,97 @@ export const RESPONSE_SCHEMA = {
 			items: {
 				type: "object",
 				properties: {
-					label: { type: "string" },
-					box_2d: {
+					labels: {
 						type: "array",
-						items: { type: "number" }
-					},
-					mask: { type: "string" },
-					points: {
-						type: "array",
-						items: {
-							type: "array",
-							items: { type: "number" }
-						}
+						items: { type: "string" },
+						minItems: 1
 					},
 					category: { type: "string" },
-					confidence: { type: "number" }
+					confidence: { type: "number" },
+					box_2d: {
+						type: "array",
+						items: { type: "number" },
+						minItems: 4,
+						maxItems: 4
+					},
+					mask: { type: "string", nullable: true },
+					safety: {
+						type: "object",
+						properties: {
+							isViolation: { type: "boolean", nullable: true },
+							severity: { type: "string", nullable: true },
+							rule: { type: "string", nullable: true }
+						},
+						nullable: true
+					},
+					progress: {
+						type: "object",
+						properties: {
+							phase: { type: "string", nullable: true },
+							percentComplete: { type: "number", nullable: true },
+							notes: { type: "string", nullable: true }
+						},
+						nullable: true
+					},
+					attributes: {
+						type: "array",
+						items: {
+							type: "object",
+							properties: {
+								name: { type: "string" },
+								valueStr: { type: "string", nullable: true },
+								valueNum: { type: "number", nullable: true },
+								valueBool: { type: "boolean", nullable: true },
+								unit: { type: "string", nullable: true }
+							},
+							required: ["name"]
+						},
+						nullable: true
+					},
+					relationships: {
+						type: "array",
+						items: {
+							type: "object",
+							properties: {
+								type: { type: "string" },
+								targetId: { type: "string" }
+							},
+							required: ["type", "targetId"]
+						},
+						nullable: true
+					}
 				},
-				required: ["label", "box_2d"]
+				required: ["labels", "category", "confidence", "box_2d"]
+			}
+		},
+		global_insights: {
+			type: "array",
+			items: {
+				type: "object",
+				properties: {
+					labels: {
+						type: "array",
+						items: { type: "string" },
+						minItems: 1
+					},
+					category: { type: "string" },
+					description: { type: "string" },
+					confidence: { type: "number" },
+					metrics: {
+						type: "array",
+						items: {
+							type: "object",
+							properties: {
+								key: { type: "string" },
+								value: { type: "number" },
+								unit: { type: "string", nullable: true }
+							},
+							required: ["key", "value"]
+						},
+						nullable: true
+					}
+				},
+				required: ["labels", "category", "description", "confidence"]
 			}
 		}
 	},

--- a/src/aec-schema.js
+++ b/src/aec-schema.js
@@ -1,16 +1,16 @@
 /* istanbul ignore file */
 
 export const AEC_PROMPT = `
-Detect all visible objects, equipment, safety issues, and facility assets in this construction/AEC image.
-Return a JSON object with an "items" array where each item includes:
+Detect the most relevant objects, equipment, safety issues, and facility assets in this construction/AEC image.
+Return a compact JSON object with an "items" array where each item includes:
 - "label": descriptive text label
 - "box_2d": bounding box as [ymin, xmin, ymax, xmax] normalized 0-1000
-- "mask": optional base64-encoded PNG segmentation mask
+- "mask": optional base64-encoded PNG segmentation mask when segmentation data is available
 - "points": optional array of key points as [y, x] pairs normalized 0-1000
 - "category": one of "object", "safety_issue", "facility_asset", "progress"
 - "confidence": 0-1 confidence score
 
-Include boxes, masks, and points when available. Limit to 25 items. Output ONLY JSON, no prose, no code fences.
+Return at most 25 items, prioritizing the highest-confidence detections. Only include masks or points when the model provides them. Output ONLY JSON, no prose, no code fences.
 `.trim();
 
 export const RESPONSE_SCHEMA = {

--- a/src/aec-schema.js
+++ b/src/aec-schema.js
@@ -1,143 +1,45 @@
 /* istanbul ignore file */
 
 export const AEC_PROMPT = `
-You are an AEC computer-vision assistant.
-Return findings strictly matching the provided response schema across FOUR categories:
-1) General objects (e.g., ladder, scaffold, duct, rebar, crane hook).
-2) Facility assets (e.g., exit sign, fire extinguisher, panel/valve).
-3) Safety issues (e.g., missing PPE, unguarded edge, ladder angle > 75°, blocked exit).
-4) Progress/scene insights (e.g., "drywall phase ~70%", "MEP rough-in present", "finishes started").
+Detect all visible objects, equipment, safety issues, and facility assets in this construction/AEC image.
+Return a JSON object with an "items" array where each item includes:
+- "label": descriptive text label
+- "box_2d": bounding box as [ymin, xmin, ymax, xmax] normalized 0-1000
+- "mask": optional base64-encoded PNG segmentation mask
+- "points": optional array of key points as [y, x] pairs normalized 0-1000
+- "category": one of "object", "safety_issue", "facility_asset", "progress"
+- "confidence": 0-1 confidence score
 
-Geometry:
-- Use bbox as [ymin, xmin, ymax, xmax] array, normalized 0-1000, top-left origin, when localizable.
-- Use polygon only when a box would be misleading (each point {x,y} normalized 0-1000).
-- For whole-image findings (e.g., overall progress), use no geometry under detections (prefer global_insights).
-
-Safety:
-- For safety items, set category: "safety_issue" and fill safety.{isViolation, severity, rule}.
-
-Progress:
-- For per-region progress, set category: "progress" and fill progress.{phase, percentComplete, notes}.
-- For overall progress, prefer global_insights (no geometry).
-
-Attributes:
-- Add useful metadata as {name, valueNum|valueStr|valueBool, unit?}, e.g., {name:"ladder_angle_deg", valueNum:68, unit:"deg"}.
-
-Coordinates:
-- Set image.coordSystem explicitly to "normalized_0_1000" (Google's 0..1000 normalization).
-Be conservative; reflect uncertainty in confidence. Output ONLY JSON (no prose).
+Include boxes, masks, and points when available. Limit to 25 items. Output ONLY JSON, no prose, no code fences.
 `.trim();
 
 export const RESPONSE_SCHEMA = {
 	type: "object",
 	properties: {
-		image: {
-			type: "object",
-			properties: {
-				width: { type: "number", nullable: true },
-				height: { type: "number", nullable: true },
-				fileName: { type: "string", nullable: true },
-				coordSystem: { type: "string", enum: ["normalized_0_1000"], nullable: true, description: "Always normalized_0_1000" }
-			},
-			nullable: true
-		},
-		detections: {
+		items: {
 			type: "array",
 			items: {
 				type: "object",
 				properties: {
-					id: { type: "string" },
 					label: { type: "string" },
-					category: { type: "string", enum: ["object","facility_asset","safety_issue","progress","other"] },
-					confidence: { type: "number" },
-					bbox: {
+					box_2d: {
 						type: "array",
-						items: { type: "number" },
-						minItems: 4,
-						maxItems: 4,
-						description: "[ymin, xmin, ymax, xmax] normalized 0-1000",
-						nullable: true
+						items: { type: "number" }
 					},
-					polygon: {
-						type: "array",
-						items: { type:"object", properties:{ x:{type:"number"}, y:{type:"number"} }, required:["x","y"] },
-						description: "Array of {x,y} points, each normalized 0-1000",
-						nullable: true
-					},
-					safety: {
-						type: "object",
-						properties: {
-							isViolation: { type: "boolean", nullable: true },
-							severity: { type: "string", enum: ["low","medium","high"], nullable: true },
-							rule: { type: "string", nullable: true }
-						},
-						nullable: true
-					},
-					progress: {
-						type: "object",
-						properties: {
-							phase: { type: "string", nullable: true },
-							percentComplete: { type: "number", nullable: true },
-							notes: { type: "string", nullable: true }
-						},
-						nullable: true
-					},
-					attributes: {
+					mask: { type: "string" },
+					points: {
 						type: "array",
 						items: {
-							type: "object",
-							properties: {
-								name: { type: "string" },
-								valueStr: { type: "string", nullable: true },
-								valueNum: { type: "number", nullable: true },
-								valueBool: { type: "boolean", nullable: true },
-								unit: { type: "string", nullable: true }
-							},
-							required: ["name"]
-						},
-						nullable: true
+							type: "array",
+							items: { type: "number" }
+						}
 					},
-					useCaseTags: { type: "array", items: { type:"string" }, nullable: true },
-					relationships: {
-						type: "array",
-						items: { type:"object", properties:{ type:{type:"string"}, targetId:{type:"string"} }, required:["type","targetId"] },
-						nullable: true
-					}
+					category: { type: "string" },
+					confidence: { type: "number" }
 				},
-				required: ["id","label","category","confidence"]
-			}
-		},
-		global_insights: {
-			type: "array",
-			items: {
-				type: "object",
-				properties: {
-					name: { type: "string" },
-					category: { type:"string", enum:["progress","safety_issue","facility_asset","object","other"] },
-					description: { type: "string" },
-					confidence: { type: "number" },
-					metrics: {
-						type: "array",
-						items: { type:"object", properties:{ key:{type:"string"}, value:{type:"number"}, unit:{type:"string",nullable:true} }, required:["key","value"] },
-						nullable: true
-					},
-					relatedDetectionIds: { type:"array", items:{type:"string"}, nullable: true },
-					region: {
-						type: "object",
-						properties: {
-							bbox: {
-								type: "object",
-								properties: { x:{type:"number"}, y:{type:"number"}, width:{type:"number"}, height:{type:"number"} },
-								required: ["x","y","width","height"],
-								nullable: true
-							}
-						},
-						nullable: true
-					}
-				},
-				required: ["name","category","description","confidence"]
+				required: ["label", "box_2d"]
 			}
 		}
 	},
-	required: ["detections","global_insights"]
+	required: ["items"]
 };

--- a/src/image-utils.js
+++ b/src/image-utils.js
@@ -1,7 +1,7 @@
 export const IMAGE_PREPROCESS_DEFAULTS = Object.freeze({
-	targetShortSide: 960,
-	minShortSide: 720,
-	maxLongSide: 1600,
+	targetShortSide: 640,
+	minShortSide: 512,
+	maxLongSide: 1280,
 	tileSize: 768,
 	outputFormat: 'image/webp',
 	quality: 0.85,

--- a/src/index.js
+++ b/src/index.js
@@ -479,7 +479,7 @@ function createTintedMaskCanvas(image, rgbColor) {
 		}
 		tempCtx.putImageData(imageData, 0, 0);
 		tinted = true;
-	} catch (err) {
+	} catch {
 		// Likely a cross-origin image; fall through to composite-based tinting
 	}
 

--- a/src/index.js
+++ b/src/index.js
@@ -546,7 +546,7 @@ async function callGeminiREST({ apiKey, model, file }) {
 
 async function analyzeImageBatch(files) {
 	const apiKey = apiKeyEl.value.trim();
-	const model  = modelEl.value.trim() || 'gemini-2.5-pro';
+	const model  = modelEl.value.trim() || 'gemini-2.5-flash';
 
 	if (!apiKey) {
 		logJson({ error: 'Missing API key' }, 'Error');

--- a/src/index.js
+++ b/src/index.js
@@ -424,6 +424,12 @@ function drawMask(maskDataUrl, boundingBox, rgbColor) {
 		);
 		ctx.restore();
 	};
+	img.onerror = () => {
+		console.warn('Failed to load segmentation mask image', {
+			sourcePreview: typeof maskDataUrl === 'string' ? maskDataUrl.slice(0, 32) : maskDataUrl,
+			boundingBox
+		});
+	};
 	
 	// Handle both data URLs and plain base64
 	if (maskDataUrl.startsWith('data:')) {

--- a/src/index.js
+++ b/src/index.js
@@ -431,11 +431,18 @@ function drawMask(maskDataUrl, boundingBox, rgbColor) {
 		});
 	};
 	
-	// Handle both data URLs and plain base64
-	if (maskDataUrl.startsWith('data:')) {
-		img.src = maskDataUrl;
+	const maskSource = typeof maskDataUrl === 'string' ? maskDataUrl.trim() : '';
+	const isLikelyBase64 = maskSource.length >= 32
+		&& /^[A-Za-z0-9+/=\s]+$/.test(maskSource)
+		&& maskSource.replace(/\s+/g, '').length % 4 === 0;
+
+	// Handle both data URLs, regular URLs, and plain base64 payloads
+	if (maskSource.startsWith('data:')) {
+		img.src = maskSource;
+	} else if (!isLikelyBase64 && maskSource.length > 0) {
+		img.src = maskSource;
 	} else {
-		img.src = `data:image/png;base64,${maskDataUrl}`;
+		img.src = `data:image/png;base64,${maskSource}`;
 	}
 }
 

--- a/src/ui-utils.js
+++ b/src/ui-utils.js
@@ -38,11 +38,7 @@ export function extractJSONFromResponse(resp) {
 	} catch (err) {
 		const cleaned = cleanupPartialMaskJson(raw);
 		if (cleaned !== raw) {
-			try {
-				return JSON.parse(cleaned);
-			} catch (secondErr) {
-				throw secondErr;
-			}
+			return JSON.parse(cleaned);
 		}
 		throw err;
 	}


### PR DESCRIPTION
This pull request significantly updates the `README.md` to reflect new capabilities and schema changes for the Gemini Vision Demo, especially around segmentation mask support, schema simplification, and improved instructions for both users and developers. The documentation now describes a more streamlined and mask-centric detection pipeline, removes polygon support, and clarifies model usage and configuration.

**Key changes include:**

### Model and Feature Updates
- Changed the default model to `gemini-2.5-flash` (selectable), and clarified support for multiple Gemini 2.5 models. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L4-R4) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L16-R20)
- The demo now supports segmentation masks (with overlays and mask rendering), removing polygons from both the UI and schema. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L16-R20) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L31) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L69-R68) [[4]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L113-R113) [[5]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R137-R175) [[6]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L212-R286) [[7]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L355-R342) [[8]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L366-R353) [[9]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L382-R369) [[10]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L413-R411) [[11]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L571-R557)

### Schema and Prompt Overhaul
- Replaced the `detections` array with an `items` array; each detection now uses a `labels` array (most specific to general), a `box_2d` bounding box, and an optional `mask`. Polygons and keypoints are no longer supported. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R137-R175) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L212-R286)
- Updated the prompt and schema instructions to match the new mask-first, polygon-free approach, and clarified the use of the `labels` array for both specific and general terms.
- Session-level aggregates are now always calculated client-side, and the schema has been further simplified to reduce hallucination risks.

### UI/UX and Workflow Improvements
- Analysis now starts automatically after file selection; removed the explicit "Analyze" button.
- Hover interactions and overlays now refer to both bounding boxes and segmentation masks, not polygons. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L113-R113) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L355-R342) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L366-R353) [[4]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L382-R369)
- Added detailed instructions for mask rendering, caching, and colorization in the UI.

### API and Performance
- Updated request/response configuration: switched to camelCase (`responseMimeType`, `responseSchema`), added `thinkingConfig` and `maxOutputTokens` for latency control.
- Added guidance to preprocess uploads (downscale images) before sending to Gemini for improved performance and latency.

### Miscellaneous
- Removed references to polygons throughout the documentation and replaced them with segmentation mask terminology. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L465-L467) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L571-R557)
- Clarified open questions and future work, especially regarding mask quality and UI affordances.